### PR TITLE
Proxy qliksense upgrade to porter upgrade

### DIFF
--- a/cmd/qliksense/aliases.go
+++ b/cmd/qliksense/aliases.go
@@ -14,6 +14,7 @@ func buildAliasCommands(porterCmd *cobra.Command, q *qliksense.Qliksense) []*cob
 	return []*cobra.Command{
 		buildBuildAlias(porterCmd),
 		buildInstallAlias(porterCmd, q),
+		buildUpgradeAlias(porterCmd, q),
 		buildAboutAlias(porterCmd),
 		buildPreflightAlias(porterCmd, q),
 		buildUninstallAlias(porterCmd, q),
@@ -100,6 +101,75 @@ For example, the 'debug' driver may be specified, which simply logs the info giv
 	f := c.Flags()
 	f.StringVarP(&opts.Version, "version", "v", "latest",
 		"Version of Qlik Sense to install")
+	f.BoolVar(&opts.Insecure, "insecure", true,
+		"Allow working with untrusted bundles")
+	f.StringVarP(&opts.File, "file", "f", "",
+		"Path to the porter manifest file. Defaults to the bundle in the current directory.")
+	f.StringVar(&opts.CNABFile, "cnab-file", "",
+		"Path to the CNAB bundle.json file.")
+	f.StringSliceVar(&opts.ParamFiles, "param-file", nil,
+		"Path to a parameters definition file for the bundle, each line in the form of NAME=VALUE. May be specified multiple times.")
+	f.StringSliceVar(&opts.Params, "param", nil,
+		"Define an individual parameter in the form NAME=VALUE. Overrides parameters set with the same name using --param-file. May be specified multiple times.")
+	f.StringSliceVarP(&opts.CredentialIdentifiers, "cred", "c", nil,
+		"Credential to use when installing the bundle. May be either a named set of credentials or a filepath, and specified multiple times.")
+	f.StringVarP(&opts.Driver, "driver", "d", "docker",
+		"Specify a driver to use. Allowed values: docker, debug")
+	f.StringVarP(&opts.Tag, "tag", "t", "",
+		"Use a bundle in an OCI registry specified by the given tag")
+	f.BoolVar(&opts.InsecureRegistry, "insecure-registry", false,
+		"Don't require TLS for the registry")
+	f.BoolVar(&opts.Force, "force", false,
+		"Force a fresh pull of the bundle and all dependencies")
+	return c
+}
+
+func buildUpgradeAlias(porterCmd *cobra.Command, q *qliksense.Qliksense) *cobra.Command {
+	var (
+		c        *cobra.Command
+		opts     *paramOptions
+		registry *string
+	)
+
+	opts = &paramOptions{}
+
+	c = &cobra.Command{
+		Use:   "upgrade [INSTANCE]",
+		Short: "Upgrade qliksense",
+		Long: `Upgrade to a new instance of a bundle.
+
+The first argument is the bundle instance name to upgrade for the installation. This defaults to the name of the bundle. 
+
+Porter uses the Docker driver as the default runtime for executing a bundle's invocation image, but an alternate driver may be supplied via '--driver/-d'.
+For example, the 'debug' driver may be specified, which simply logs the info given to it and then exits.`,
+		Example: `  qliksense upgrade
+  qliksense upgrade --version v1.0.0
+  qliksense upgrade --insecure
+  qliksense upgrade qliksense --file qliksense/bundle.json
+  qliksense upgrade --param-file base-values.txt --param-file dev-values.txt --param test-mode=true --param header-color=blue
+  qliksense upgrade --cred kubernetes
+  qliksense upgrade --driver debug
+  qliksense upgrade MyAppFromTag --tag qlik/qliksense-cnab-bundle:v1.0.0
+`,
+		//DisableFlagParsing: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Push images here.
+			// TODO: Need to get the private reg from params
+			args = append(os.Args[2:], opts.getTagValue(args)...)
+			if registry = opts.findKey("dockerRegistry"); registry != nil {
+				if len(*registry) > 0 {
+					q.TagAndPushImages(*registry)
+				}
+			}
+			return porterCmd.RunE(porterCmd, append([]string{"upgrade"}, args...))
+		},
+		Annotations: map[string]string{
+			"group": "alias",
+		},
+	}
+	f := c.Flags()
+	f.StringVarP(&opts.Version, "version", "v", "latest",
+		"Version of Qlik Sense to upgrade to")
 	f.BoolVar(&opts.Insecure, "insecure", true,
 		"Allow working with untrusted bundles")
 	f.StringVarP(&opts.File, "file", "f", "",


### PR DESCRIPTION
```
MacBook-Pro:qliksense-k8s dlx$ /Users/dlx/go/mod/sense-installer/bin/qliksense upgrade --param acceptEULA=yes -c QLIKSENSE
```
```
upgrading Qliksense...
executing upgrade action from Qliksense (bundle instance: Qliksense)
Upgrading: Creating patch based on CR
applying patch ...
2020/01/15 21:05:24 running qliksense-operator .... 
2020/01/15 21:05:24 manifests are in local file system in /cnab/app
2020/01/15 21:05:24 restoring keys from the cluster
2020/01/15 21:05:24 exiting qliksense-operator
applying patch finished.
Upgrading: Use Kustomize to generate the k8s resources for Qliksense
2020/01/15 21:05:59 nil value at `volumes.configMap.name` ignored in mutation attempt
2020/01/15 21:05:59 nil value at `volumes.projected.sources.configMap.name` ignored in mutation attempt
2020/01/15 21:05:59 nil value at `volumes.secret.secretName` ignored in mutation attempt
2020/01/15 21:05:59 nil value at `volumes.projected.sources.secret.name` ignored in mutation attempt
2020/01/15 21:05:59 nil value at `volumes.persistentVolumeClaim.claimName` ignored in mutation attempt
2020/01/15 21:05:59 nil value at `volumes.configMap.name` ignored in mutation attempt
2020/01/15 21:05:59 nil value at `volumes.projected.sources.configMap.name` ignored in mutation attempt
2020/01/15 21:05:59 nil value at `volumes.secret.secretName` ignored in mutation attempt
2020/01/15 21:05:59 nil value at `volumes.projected.sources.secret.name` ignored in mutation attempt
2020/01/15 21:05:59 nil value at `volumes.persistentVolumeClaim.claimName` ignored in mutation attempt
2020/01/15 21:06:05 nil value at `volumes.configMap.name` ignored in mutation attempt
2020/01/15 21:06:05 nil value at `volumes.projected.sources.configMap.name` ignored in mutation attempt
2020/01/15 21:06:05 nil value at `volumes.secret.secretName` ignored in mutation attempt
2020/01/15 21:06:05 nil value at `volumes.projected.sources.secret.name` ignored in mutation attempt
2020/01/15 21:06:05 nil value at `volumes.persistentVolumeClaim.claimName` ignored in mutation attempt
2020/01/15 21:06:05 nil value at `volumes.configMap.name` ignored in mutation attempt
2020/01/15 21:06:05 nil value at `volumes.projected.sources.configMap.name` ignored in mutation attempt
2020/01/15 21:06:05 nil value at `volumes.secret.secretName` ignored in mutation attempt
2020/01/15 21:06:05 nil value at `volumes.projected.sources.secret.name` ignored in mutation attempt
2020/01/15 21:06:05 nil value at `volumes.persistentVolumeClaim.claimName` ignored in mutation attempt
2020/01/15 21:06:06 nil value at `volumes.configMap.name` ignored in mutation attempt
2020/01/15 21:06:06 nil value at `volumes.projected.sources.configMap.name` ignored in mutation attempt
2020/01/15 21:06:06 nil value at `volumes.secret.secretName` ignored in mutation attempt
2020/01/15 21:06:06 nil value at `volumes.projected.sources.secret.name` ignored in mutation attempt
2020/01/15 21:06:06 nil value at `volumes.persistentVolumeClaim.claimName` ignored in mutation attempt
2020/01/15 21:06:06 nil value at `volumes.configMap.name` ignored in mutation attempt
2020/01/15 21:06:06 nil value at `volumes.projected.sources.configMap.name` ignored in mutation attempt
2020/01/15 21:06:06 nil value at `volumes.secret.secretName` ignored in mutation attempt
2020/01/15 21:06:06 nil value at `volumes.projected.sources.secret.name` ignored in mutation attempt
2020/01/15 21:06:06 nil value at `volumes.persistentVolumeClaim.claimName` ignored in mutation attempt
2020/01/15 21:06:15 nil value at `volumes.configMap.name` ignored in mutation attempt
2020/01/15 21:06:15 nil value at `volumes.projected.sources.configMap.name` ignored in mutation attempt
2020/01/15 21:06:15 nil value at `volumes.secret.secretName` ignored in mutation attempt
2020/01/15 21:06:15 nil value at `volumes.projected.sources.secret.name` ignored in mutation attempt
2020/01/15 21:06:15 nil value at `volumes.persistentVolumeClaim.claimName` ignored in mutation attempt
2020/01/15 21:06:15 nil value at `volumes.configMap.name` ignored in mutation attempt
2020/01/15 21:06:15 nil value at `volumes.projected.sources.configMap.name` ignored in mutation attempt
2020/01/15 21:06:15 nil value at `volumes.secret.secretName` ignored in mutation attempt
2020/01/15 21:06:15 nil value at `volumes.projected.sources.secret.name` ignored in mutation attempt
2020/01/15 21:06:15 nil value at `volumes.persistentVolumeClaim.claimName` ignored in mutation attempt
2020/01/15 21:06:15 nil value at `volumes.configMap.name` ignored in mutation attempt
2020/01/15 21:06:15 nil value at `volumes.projected.sources.configMap.name` ignored in mutation attempt
2020/01/15 21:06:15 nil value at `volumes.secret.secretName` ignored in mutation attempt
2020/01/15 21:06:15 nil value at `volumes.projected.sources.secret.name` ignored in mutation attempt
2020/01/15 21:06:15 nil value at `volumes.persistentVolumeClaim.claimName` ignored in mutation attempt
2020/01/15 21:06:15 nil value at `data.mongoDbUri` ignored in mutation attempt
2020/01/15 21:06:15 nil value at `data.mongoDbUri` ignored in mutation attempt
2020/01/15 21:06:15 nil value at `volumeMounts.mountPath` ignored in mutation attempt
2020/01/15 21:06:15 nil value at `volumes.configMap.name` ignored in mutation attempt
2020/01/15 21:06:15 nil value at `volumes.persistentVolumeClaim.claimName` ignored in mutation attempt
2020/01/15 21:06:15 nil value at `volumeMounts.mountPath` ignored in mutation attempt
2020/01/15 21:06:15 nil value at `volumes.secret.secretName` ignored in mutation attempt
2020/01/15 21:06:15 nil value at `volumes.configMap.name` ignored in mutation attempt
2020/01/15 21:06:15 nil value at `volumes.persistentVolumeClaim.claimName` ignored in mutation attempt
2020/01/15 21:06:15 nil value at `volumeMounts.mountPath` ignored in mutation attempt
2020/01/15 21:06:15 nil value at `volumes.secret.secretName` ignored in mutation attempt
2020/01/15 21:06:15 nil value at `volumes.configMap.name` ignored in mutation attempt
2020/01/15 21:06:15 nil value at `volumes.persistentVolumeClaim.claimName` ignored in mutation attempt
2020/01/15 21:06:15 nil value at `volumeMounts.mountPath` ignored in mutation attempt
2020/01/15 21:06:15 nil value at `volumes.secret.secretName` ignored in mutation attempt
2020/01/15 21:06:15 well-defined vars that were never replaced: STORAGE_CLASS_NAME
Upgrading: run Kubernetes to create/upgrade k8s resource
serviceaccount/qliksense-chronos unchanged
serviceaccount/qliksense-elastic-infra-nginx-ingress unchanged
serviceaccount/qliksense-encryption unchanged
serviceaccount/qliksense-licenses unchanged
serviceaccount/qliksense-odag unchanged
serviceaccount/qliksense-qix-sessions unchanged
role.rbac.authorization.k8s.io/qliksense-chronos unchanged
role.rbac.authorization.k8s.io/qliksense-elastic-infra-nginx-ingress unchanged
role.rbac.authorization.k8s.io/qliksense-licenses unchanged
role.rbac.authorization.k8s.io/qliksense-odag unchanged
role.rbac.authorization.k8s.io/qliksense-qix-sessions unchanged
rolebinding.rbac.authorization.k8s.io/qliksense-chronos unchanged
rolebinding.rbac.authorization.k8s.io/qliksense-elastic-infra-nginx-ingress unchanged
rolebinding.rbac.authorization.k8s.io/qliksense-licenses unchanged
rolebinding.rbac.authorization.k8s.io/qliksense-odag unchanged
rolebinding.rbac.authorization.k8s.io/qliksense-qix-sessions unchanged
configmap/qliksense-audit-configs-dmfm2fmthc unchanged
configmap/qliksense-chronos-configs-g99286b86k unchanged
configmap/qliksense-chronos-worker-configs-d9d6gdmkfd unchanged
configmap/qliksense-collections-configs-bc78d5gk78 unchanged
configmap/qliksense-configs-t26m28f475 unchanged
configmap/qliksense-data-connector-odbc-configs-hb45dk82c9 unchanged
configmap/qliksense-data-connector-qwc-configs-gtc2fd5m86 unchanged
configmap/qliksense-data-connector-rest-configs-75bcfmd79d unchanged
configmap/qliksense-data-prep-configs-6hkbmd64kd unchanged
configmap/qliksense-data-rest-source-configs-bhfg925dkk unchanged
configmap/qliksense-dcaas-configs-tk5t9gmtd2 unchanged
configmap/qliksense-dcaas-redis unchanged
configmap/qliksense-dcaas-redis-health unchanged
configmap/qliksense-dcaas-web-configs-67fch8g8m6 unchanged
configmap/qliksense-edge-auth-configs-bfk4hk58k2 unchanged
configmap/qliksense-elastic-infra-configs-tfg97gg22k unchanged
configmap/qliksense-elastic-infra-nginx-ingress-controller unchanged
configmap/qliksense-encryption-configs-6t8mf2chcb unchanged
configmap/qliksense-engine-configs-tm467hdbd4 unchanged
configmap/qliksense-engine-engine-rules-cm unchanged
configmap/qliksense-eventing-configs-66689tmb8m unchanged
configmap/qliksense-feature-flags-configmap unchanged
configmap/qliksense-feature-flags-configs-bhgd28h2t5 unchanged
configmap/qliksense-generic-links-configs-g85hh57b6g unchanged
configmap/qliksense-geo-operations-configs-d484h7bcb4 unchanged
configmap/qliksense-groups-configs-8mh8h8dc56 unchanged
configmap/qliksense-hub-configs-hbd8bd6446 unchanged
configmap/qliksense-identity-providers-configs-d6877t78hm unchanged
configmap/qliksense-insights-configs-t6ftf27dd5 unchanged
configmap/qliksense-keys-configs-5mg2fm5ccf unchanged
configmap/qliksense-licenses-configs-4fbdct54b4 unchanged
configmap/qliksense-locale-configs-g2b64824c5 unchanged
configmap/qliksense-management-console-configs-m8t7h76h4h unchanged
configmap/qliksense-messaging-configs-hmmbf8ghg7 unchanged
configmap/qliksense-messaging-nats unchanged
configmap/qliksense-mongodb-configs-g8hmkgkgk2 unchanged
configmap/qliksense-nl-broker-configs-2d6g6595h4 unchanged
configmap/qliksense-nl-parser-configs-5kcfm5c877 unchanged
configmap/qliksense-odag-configs-7h6dm8bk7t unchanged
configmap/qliksense-policy-decisions-configs-mc7k7cgkc2 unchanged
configmap/qliksense-precedents-configs-8hg85mf574 unchanged
configmap/qliksense-qix-data-connection-configs-h8d7h22b9c unchanged
configmap/qliksense-qix-data-reload-configs-fbbt544k27 unchanged
configmap/qliksense-qix-datafiles-configs-b2gktgtmt4 unchanged
configmap/qliksense-qix-sessions-configs-ht46k686dg unchanged
configmap/qliksense-qlikview-client-configs-9245h2t282 unchanged
configmap/qliksense-quotas-configs-dm49m86ht9 unchanged
configmap/qliksense-redis unchanged
configmap/qliksense-redis-configs-c7hm7th5f7 unchanged
configmap/qliksense-redis-health unchanged
configmap/qliksense-reload-tasks-configs-tf8gg5d4md unchanged
configmap/qliksense-reporting-configs-22d28kg5bb unchanged
configmap/qliksense-resource-library-configs-fd4g99k5mf unchanged
configmap/qliksense-space-client-configs-6g8d96797g unchanged
configmap/qliksense-spaces-configs-654ftth4k4 unchanged
configmap/qliksense-temporary-contents-configs-hh228g6b5t unchanged
configmap/qliksense-tenants-configmap unchanged
configmap/qliksense-tenants-configs-6tc689g652 unchanged
configmap/qliksense-users-configs-797g2bt77f unchanged
secret/qliksense-audit-secrets-h7md7c5896 configured
secret/qliksense-chronos-secrets-k69tk64c8b configured
secret/qliksense-chronos-worker-secrets-m7b44t8mgm configured
secret/qliksense-collections-secrets-dm464ct82f configured
secret/qliksense-collections-tokenconfig configured
secret/qliksense-data-connector-odbc-secrets-k95fckhfhd configured
secret/qliksense-data-connector-qwc-secrets-c4fmk54k9k unchanged
secret/qliksense-data-connector-rest-secrets-9594gt9b25 configured
secret/qliksense-data-prep-secrets-4hc528cddt configured
secret/qliksense-data-rest-source-secrets-b4d8b48kmf configured
secret/qliksense-dcaas-dcaas-redis-secret configured
secret/qliksense-dcaas-secrets-kh87dtggd5 configured
secret/qliksense-dcaas-web-secrets-6t67h4gb65 configured
secret/qliksense-edge-auth-secrets-262cmdd748 configured
secret/qliksense-elastic-infra-elastic-infra-tls-secret configured
secret/qliksense-elastic-infra-secrets-g7529c95dc configured
secret/qliksense-encryption-secrets-5c8b9ddb94 configured
secret/qliksense-engine-secrets-tdm5gc6t76 configured
secret/qliksense-engine-service-jwt-secret unchanged
secret/qliksense-eventing-secret unchanged
secret/qliksense-eventing-secrets-54mfd4hhfd configured
secret/qliksense-generic-links-secrets-9mkddf987b configured
secret/qliksense-generic-links-tokenconfig configured
secret/qliksense-geo-operations-secrets-kgfk64tf56 configured
secret/qliksense-groups-secret unchanged
secret/qliksense-groups-secrets-fkt8gf85b6 configured
secret/qliksense-hub-secrets-tc9b68kd8m unchanged
secret/qliksense-identity-providers-secrets-ccc9cgf2fk configured
secret/qliksense-insights-secrets-4kmtct849t configured
secret/qliksense-licenses-secrets-8h996t69k7 configured
secret/qliksense-messaging-message-delivery-monitor-secret configured
secret/qliksense-messaging-nats-secret unchanged
secret/qliksense-messaging-secrets-6gc44b57mh configured
secret/qliksense-mongodb-secrets-h5b9k65c5h unchanged
secret/qliksense-nl-broker-secrets-g847gm2fdc configured
secret/qliksense-nl-parser-secrets-8c52742f99 configured
secret/qliksense-odag-secrets-h29k4md4gb configured
secret/qliksense-policy-decisions-secrets-7b966f6ctc configured
secret/qliksense-precedents-secret unchanged
secret/qliksense-precedents-secrets-mbh8d6btcd configured
secret/qliksense-qix-data-connection-qdc-keysconfig unchanged
secret/qliksense-qix-data-connection-secrets-5c47kt24ck configured
secret/qliksense-qix-data-reload-privatekey configured
secret/qliksense-qix-data-reload-secrets-298h7dg46c configured
secret/qliksense-qix-datafiles-secrets-ctht56m2th configured
secret/qliksense-qix-datafiles-tokenconfig unchanged
secret/qliksense-qix-sessions-secrets-k98k8729b6 configured
secret/qliksense-qlikview-client-secrets-45k4mdt6kg configured
secret/qliksense-quotas-secrets-hf264f8458 configured
secret/qliksense-redis-secrets-96b2gt22fm configured
secret/qliksense-reload-tasks-secrets-c9t2d5mhbc configured
secret/qliksense-reporting-secrets-kbdb6942c8 configured
secret/qliksense-resource-library-secret unchanged
secret/qliksense-resource-library-secrets-bg22bb75hc configured
secret/qliksense-secrets-59c74hk4tb unchanged
secret/qliksense-spaces-secrets-kmd76g5cmg configured
secret/qliksense-spaces-tokenconfig unchanged
secret/qliksense-temporary-contents-secrets-bthhd8m7b5 configured
secret/qliksense-tenants-secret unchanged
secret/qliksense-tenants-secrets-mf69h699k2 configured
secret/qliksense-users-secret unchanged
secret/qliksense-users-secrets-9hdh8d7796 configured
service/qliksense-audit unchanged
service/qliksense-chronos unchanged
service/qliksense-chronos-worker unchanged
service/qliksense-collections unchanged
service/qliksense-data-connector-odbc-cmd unchanged
service/qliksense-data-connector-odbc-rld unchanged
service/qliksense-data-connector-qwc-cmd unchanged
service/qliksense-data-connector-qwc-rld unchanged
service/qliksense-data-connector-rest-cmd unchanged
service/qliksense-data-connector-rest-rld unchanged
service/qliksense-data-prep unchanged
service/qliksense-data-rest-source unchanged
service/qliksense-dcaas unchanged
service/qliksense-dcaas-redis-master unchanged
service/qliksense-dcaas-redis-slave unchanged
service/qliksense-dcaas-web unchanged
service/qliksense-edge-auth unchanged
service/qliksense-elastic-infra-nginx-ingress-controller unchanged
service/qliksense-elastic-infra-nginx-ingress-controller-metrics unchanged
service/qliksense-encryption unchanged
service/qliksense-engine unchanged
service/qliksense-eventing unchanged
service/qliksense-feature-flags unchanged
service/qliksense-generic-links unchanged
service/qliksense-geo-operations unchanged
service/qliksense-groups unchanged
service/qliksense-hub unchanged
service/qliksense-identity-providers unchanged
service/qliksense-insights unchanged
service/qliksense-keys unchanged
service/qliksense-licenses unchanged
service/qliksense-locale unchanged
service/qliksense-management-console unchanged
service/qliksense-messaging-nats-client unchanged
service/qliksense-messaging-nats-cluster unchanged
service/qliksense-messaging-nats-headless unchanged
service/qliksense-messaging-nats-monitoring unchanged
service/qliksense-messaging-nats-streaming-monitoring unchanged
service/qliksense-mongodb unchanged
service/qliksense-nl-broker unchanged
service/qliksense-nl-parser unchanged
service/qliksense-odag unchanged
service/qliksense-policy-decisions unchanged
service/qliksense-precedents unchanged
service/qliksense-precedents-cayley unchanged
service/qliksense-qix-data-connection unchanged
service/qliksense-qix-data-reload unchanged
service/qliksense-qix-datafiles unchanged
service/qliksense-qix-sessions unchanged
service/qliksense-qlikview-client unchanged
service/qliksense-quotas unchanged
service/qliksense-redis-master unchanged
service/qliksense-redis-slave unchanged
service/qliksense-reload-tasks unchanged
service/qliksense-reporting unchanged
service/qliksense-reporting-cmp unchanged
service/qliksense-reporting-rpr unchanged
service/qliksense-reporting-rwr unchanged
service/qliksense-resource-library unchanged
service/qliksense-sense-client unchanged
service/qliksense-spaces unchanged
service/qliksense-temporary-contents unchanged
service/qliksense-tenants unchanged
service/qliksense-users unchanged
deployment.apps/qliksense-audit unchanged
deployment.apps/qliksense-chronos unchanged
deployment.apps/qliksense-chronos-worker unchanged
deployment.apps/qliksense-collections unchanged
deployment.apps/qliksense-data-connector-odbc-cmd unchanged
deployment.apps/qliksense-data-connector-odbc-rld unchanged
deployment.apps/qliksense-data-connector-qwc-cmd unchanged
deployment.apps/qliksense-data-connector-qwc-rld unchanged
deployment.apps/qliksense-data-connector-rest-cmd unchanged
deployment.apps/qliksense-data-connector-rest-rld unchanged
deployment.apps/qliksense-data-prep configured
deployment.apps/qliksense-data-rest-source unchanged
deployment.apps/qliksense-dcaas unchanged
deployment.apps/qliksense-dcaas-redis-slave configured
deployment.apps/qliksense-dcaas-web unchanged
deployment.apps/qliksense-edge-auth unchanged
deployment.apps/qliksense-elastic-infra-nginx-ingress-controller configured
deployment.apps/qliksense-encryption configured
deployment.apps/qliksense-engine-default configured
deployment.apps/qliksense-engine-qlikview-default configured
deployment.apps/qliksense-eventing unchanged
deployment.apps/qliksense-feature-flags unchanged
deployment.apps/qliksense-generic-links unchanged
deployment.apps/qliksense-geo-operations configured
deployment.apps/qliksense-groups unchanged
deployment.apps/qliksense-hub unchanged
deployment.apps/qliksense-identity-providers unchanged
deployment.apps/qliksense-insights configured
deployment.apps/qliksense-keys configured
deployment.apps/qliksense-licenses configured
deployment.apps/qliksense-locale configured
deployment.apps/qliksense-management-console configured
deployment.apps/qliksense-mongodb configured
deployment.apps/qliksense-nl-broker unchanged
deployment.apps/qliksense-nl-parser unchanged
deployment.apps/qliksense-odag unchanged
deployment.apps/qliksense-policy-decisions configured
deployment.apps/qliksense-precedents configured
deployment.apps/qliksense-qix-data-connection unchanged
deployment.apps/qliksense-qix-data-reload configured
deployment.apps/qliksense-qix-datafiles unchanged
deployment.apps/qliksense-qix-sessions unchanged
deployment.apps/qliksense-qlikview-client configured
deployment.apps/qliksense-quotas unchanged
deployment.apps/qliksense-redis-slave configured
deployment.apps/qliksense-reload-tasks configured
deployment.apps/qliksense-reporting configured
deployment.apps/qliksense-resource-library configured
deployment.apps/qliksense-sense-client unchanged
deployment.apps/qliksense-spaces unchanged
deployment.apps/qliksense-temporary-contents configured
deployment.apps/qliksense-tenants unchanged
deployment.apps/qliksense-users unchanged
statefulset.apps/qliksense-dcaas-redis-master configured
statefulset.apps/qliksense-messaging-nats configured
statefulset.apps/qliksense-messaging-nats-streaming configured
statefulset.apps/qliksense-redis-master configured
cronjob.batch/qliksense-insights-pruning unchanged
cronjob.batch/qliksense-precedents-pruning configured
ingress.extensions/qliksense-audit unchanged
ingress.extensions/qliksense-collections unchanged
ingress.extensions/qliksense-data-prep unchanged
ingress.extensions/qliksense-dcaas unchanged
ingress.extensions/qliksense-dcaas-web unchanged
ingress.extensions/qliksense-edge-auth unchanged
ingress.extensions/qliksense-edge-auth-api unchanged
ingress.extensions/qliksense-elastic-infra-elastic-infra-api-404 unchanged
ingress.extensions/qliksense-engine unchanged
ingress.extensions/qliksense-eventing unchanged
ingress.extensions/qliksense-feature-flags unchanged
ingress.extensions/qliksense-generic-links unchanged
ingress.extensions/qliksense-groups unchanged
ingress.extensions/qliksense-hub unchanged
ingress.extensions/qliksense-insights-api unchanged
ingress.extensions/qliksense-insights-insight unchanged
ingress.extensions/qliksense-insights-share unchanged
ingress.extensions/qliksense-licenses unchanged
ingress.extensions/qliksense-locale unchanged
ingress.extensions/qliksense-management-console unchanged
ingress.extensions/qliksense-nl-broker unchanged
ingress.extensions/qliksense-nl-parser unchanged
ingress.extensions/qliksense-odag unchanged
ingress.extensions/qliksense-odag-api unchanged
ingress.extensions/qliksense-policy-decisions unchanged
ingress.extensions/qliksense-precedents unchanged
ingress.extensions/qliksense-qix-data-connection unchanged
ingress.extensions/qliksense-qix-data-reload unchanged
ingress.extensions/qliksense-qix-datafiles unchanged
ingress.extensions/qliksense-qlikview-client unchanged
ingress.extensions/qliksense-qlikview-client-ajax unchanged
ingress.extensions/qliksense-quotas unchanged
ingress.extensions/qliksense-reload-tasks unchanged
ingress.extensions/qliksense-reporting unchanged
ingress.extensions/qliksense-resource-library unchanged
ingress.extensions/qliksense-sense-client unchanged
ingress.extensions/qliksense-sense-client-resources unchanged
ingress.extensions/qliksense-spaces unchanged
ingress.extensions/qliksense-temporary-contents unchanged
ingress.extensions/qliksense-tenants unchanged
ingress.extensions/qliksense-tenants-web-integrations unchanged
ingress.extensions/qliksense-users unchanged
networkpolicy.networking.k8s.io/qliksense-chronos-worker-deny-external-egress unchanged
engine.qixmanager.qlik.com/qliksense-engine-reload unchanged
persistentvolumeclaim/qliksense-engine unchanged
persistentvolumeclaim/qliksense-qix-datafiles unchanged
persistentvolumeclaim/qliksense-resource-library unchanged
persistentvolumeclaim/qliksense-temporary-contents unchanged
execution completed successfully!
MacBook-Pro:qliksense-k8s dlx$ 

```