### PR TITLE
QlikSense config list-contexts

### DIFF
--- a/cmd/qliksense/context.go
+++ b/cmd/qliksense/context.go
@@ -21,6 +21,22 @@ func setContextConfigCmd(q *qliksense.Qliksense) *cobra.Command {
 	return cmd
 }
 
+func listContextConfigCmd(q *qliksense.Qliksense) *cobra.Command {
+	var (
+		cmd *cobra.Command
+	)
+
+	cmd = &cobra.Command{
+		Use:     "list-contexts",
+		Short:   "retrieves the contexts and lists them",
+		Example: `qliksense config list-contexts`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return q.ListContextConfigs()
+		},
+	}
+	return cmd
+}
+
 func setOtherConfigsCmd(q *qliksense.Qliksense) *cobra.Command {
 	var (
 		cmd *cobra.Command

--- a/cmd/qliksense/root.go
+++ b/cmd/qliksense/root.go
@@ -141,6 +141,9 @@ func rootCmd(p *qliksense.Qliksense) *cobra.Command {
 	// add the set ### config command as a sub-command to the app config sub-command
 	configCmd.AddCommand(setSecretsCmd(p))
 
+	// add the list config command as a sub-command to the app config sub-command
+	configCmd.AddCommand(listContextConfigCmd(p))
+
 	// add uninstall command
 	cmd.AddCommand(uninstallCmd(p))
 	return cmd

--- a/pkg/qliksense/context_configs.go
+++ b/pkg/qliksense/context_configs.go
@@ -7,10 +7,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"text/tabwriter"
 
 	b64 "encoding/base64"
 
 	"github.com/qlik-oss/sense-installer/pkg/api"
+	"github.com/ttacon/chalk"
 )
 
 const (
@@ -234,11 +236,16 @@ func (q *Qliksense) ListContextConfigs() error {
 	qliksenseConfigFile := filepath.Join(q.QliksenseHome, QliksenseConfigFile)
 	var qliksenseConfig api.QliksenseConfig
 	api.ReadFromFile(&qliksenseConfig, qliksenseConfigFile)
+	w := tabwriter.NewWriter(os.Stdout, 5, 8, 0, '\t', 0)
+	fmt.Fprintln(w, chalk.Underline.TextStyle("Context Name"), "\t", chalk.Underline.TextStyle("CR File Location"))
+	w.Flush()
 	if len(qliksenseConfig.Spec.Contexts) > 0 {
 		for _, cont := range qliksenseConfig.Spec.Contexts {
-			fmt.Println("Context Name : ", cont.Name, " CR File Location: ", cont.CrFile)
+			fmt.Fprintln(w, cont.Name, "\t", cont.CrFile, "\t")
 		}
-		fmt.Println("Current Context : ", qliksenseConfig.Spec.CurrentContext)
+		w.Flush()
+		fmt.Println("")
+		fmt.Println(chalk.Bold.TextStyle("Current Context : "), qliksenseConfig.Spec.CurrentContext)
 	} else {
 		fmt.Println("No Contexts Available")
 	}

--- a/pkg/qliksense/context_configs.go
+++ b/pkg/qliksense/context_configs.go
@@ -230,6 +230,21 @@ func (q *Qliksense) SetContextConfig(args []string) error {
 	return nil
 }
 
+func (q *Qliksense) ListContextConfigs() error {
+	qliksenseConfigFile := filepath.Join(q.QliksenseHome, QliksenseConfigFile)
+	var qliksenseConfig api.QliksenseConfig
+	api.ReadFromFile(&qliksenseConfig, qliksenseConfigFile)
+	if len(qliksenseConfig.Spec.Contexts) > 0 {
+		for _, cont := range qliksenseConfig.Spec.Contexts {
+			fmt.Println("Context Name : ", cont.Name, " CR File Location: ", cont.CrFile)
+		}
+		fmt.Println("Current Context : ", qliksenseConfig.Spec.CurrentContext)
+	} else {
+		fmt.Println("No Contexts Available")
+	}
+	return nil
+}
+
 // SetUpQliksenseDefaultContext - to setup dir structure for default qliksense context
 func (q *Qliksense) SetUpQliksenseDefaultContext() error {
 	return q.SetUpQliksenseContext(DefaultQliksenseContext, true)


### PR DESCRIPTION
added sub-command to qliksense config that lists all contexts with CR Path as well as the name of current context.

command: 
"qliksense config list-contexts"
