### PR TITLE
Adding operations for docker registry secret marshalling/unmarshalling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,12 +49,15 @@ require (
 	golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a // indirect
 	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
 	golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae // indirect
-	golang.org/x/tools v0.0.0-20200225022059-a0ec867d517c // indirect
+	golang.org/x/tools v0.0.0-20200225230052-807dcd883420 // indirect
 	google.golang.org/genproto v0.0.0-20200128133413-58ce757ed39b // indirect
 	google.golang.org/grpc v1.27.0 // indirect
 	gopkg.in/yaml.v2 v2.2.8
 	gopkg.in/yaml.v3 v3.0.0-20190924164351-c8b7dadae555
+	k8s.io/api v0.17.0
+	k8s.io/apimachinery v0.17.0
 	sigs.k8s.io/kustomize/api v0.3.2
+	sigs.k8s.io/yaml v1.1.0
 )
 
 exclude github.com/Azure/go-autorest v12.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -380,6 +380,7 @@ github.com/gobuffalo/packd v0.3.0 h1:eMwymTkA1uXsqxS0Tpoop3Lc0u3kTfiMBE6nKtQU4g4
 github.com/gobuffalo/packd v0.3.0/go.mod h1:zC7QkmNkYVGKPw4tHpBQ+ml7W/3tIebgeo1b36chA3Q=
 github.com/gobuffalo/packd v1.0.0 h1:6ERZvJHfe24rfFmA9OaoKBdC7+c9sydrytMg8SdFGBM=
 github.com/gobuffalo/packd v1.0.0/go.mod h1:6VTc4htmJRFB7u1m/4LeMTWjFoYrUiBkU9Fdec9hrhI=
+github.com/gobuffalo/packr v1.30.1 h1:hu1fuVR3fXEZR7rXNW3h8rqSML8EVAf6KNm0NKO/wKg=
 github.com/gobuffalo/packr/v2 v2.7.1 h1:n3CIW5T17T8v4GGK5sWXLVWJhCz7b5aNLSxW6gYim4o=
 github.com/gobuffalo/packr/v2 v2.7.1/go.mod h1:qYEvAazPaVxy7Y7KR0W8qYEE+RymX74kETFqjFoFlOc=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
@@ -1200,8 +1201,8 @@ golang.org/x/tools v0.0.0-20200117161641-43d50277825c h1:2EA2K0k9bcvvEDlqD8xdlOh
 golang.org/x/tools v0.0.0-20200117161641-43d50277825c/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200224181240-023911ca70b2 h1:L/G4KZvrQn7FWLN/LlulBtBzrLUhqjiGfTWWDmrh+IQ=
 golang.org/x/tools v0.0.0-20200224181240-023911ca70b2/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
-golang.org/x/tools v0.0.0-20200225022059-a0ec867d517c h1:cmkqWf0jTLsPn3dn28dkzCF+MoDvuZS7pTwHwGmkqiU=
-golang.org/x/tools v0.0.0-20200225022059-a0ec867d517c/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200225230052-807dcd883420 h1:4RJNOV+2rLxMEfr6QIpC7GEv9MjD6ApGXTCLrNF9+eA=
+golang.org/x/tools v0.0.0-20200225230052-807dcd883420/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/api/docker_registry_secret.go
+++ b/pkg/api/docker_registry_secret.go
@@ -8,7 +8,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/yaml"
 )
 
 type k8sDockerConfigJsonMapType struct {
@@ -67,22 +66,12 @@ func (d *DockerConfigJsonSecret) ToYaml() ([]byte, error) {
 		},
 	}
 
-	//need this to remove the unnecessary metadata.creationTimestamp field:
-	k8sSecretYamlMap := map[string]interface{}{}
-	if k8sSecretYamlBytes, err := yaml.Marshal(k8sSecret); err != nil {
-		return nil, err
-	} else if err := yaml.Unmarshal(k8sSecretYamlBytes, &k8sSecretYamlMap); err != nil {
-		return nil, err
-	} else {
-		delete(k8sSecretYamlMap["metadata"].(map[string]interface{}), "creationTimestamp")
-		return yaml.Marshal(k8sSecretYamlMap)
-	}
+	return K8sSecretToYaml(k8sSecret)
 }
 
 func (d *DockerConfigJsonSecret) FromYaml(secretBytes []byte) error {
-	k8sSecret := v1.Secret{}
 	k8sDockerConfigJsonMap := k8sDockerConfigJsonMapType{}
-	if err := yaml.UnmarshalStrict(secretBytes, &k8sSecret); err != nil {
+	if k8sSecret, err := K8sSecretFromYaml(secretBytes); err != nil {
 		return err
 	} else if k8sSecret.TypeMeta.Kind != "Secret" {
 		return errors.New("not a Secret kind")

--- a/pkg/api/docker_registry_secret.go
+++ b/pkg/api/docker_registry_secret.go
@@ -1,0 +1,107 @@
+package api
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+)
+
+type k8sDockerConfigJsonMapType struct {
+	Auths map[string]k8sDockerConfigJsonType `json:"auths"`
+}
+
+type k8sDockerConfigJsonType struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+	Email    string `json:"email,omitempty"`
+	Auth     string `json:"auth"`
+}
+
+func (kdcjt *k8sDockerConfigJsonType) GenerateAuth() {
+	kdcjt.Auth = base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", kdcjt.Username, kdcjt.Password)))
+}
+
+type DockerConfigJsonSecret struct {
+	Name      string
+	Namespace string
+	Uri       string
+	Username  string
+	Password  string
+	Email     string
+}
+
+func (d *DockerConfigJsonSecret) ToYaml() ([]byte, error) {
+	k8sDockerConfigJson := k8sDockerConfigJsonType{
+		Username: d.Username,
+		Password: d.Password,
+		Email:    d.Email,
+	}
+	k8sDockerConfigJson.GenerateAuth()
+	k8sDockerConfigJsonMap := k8sDockerConfigJsonMapType{
+		Auths: map[string]k8sDockerConfigJsonType{
+			d.Uri: k8sDockerConfigJson,
+		},
+	}
+	k8sDockerConfigJsonMapBytes, err := json.Marshal(k8sDockerConfigJsonMap)
+	if err != nil {
+		return nil, err
+	}
+
+	k8sSecret := v1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      d.Name,
+			Namespace: d.Namespace,
+		},
+		Type: v1.SecretTypeDockerConfigJson,
+		Data: map[string][]byte{
+			".dockerconfigjson": k8sDockerConfigJsonMapBytes,
+		},
+	}
+
+	//need this to remove the unnecessary metadata.creationTimestamp field:
+	k8sSecretYamlMap := map[string]interface{}{}
+	if k8sSecretYamlBytes, err := yaml.Marshal(k8sSecret); err != nil {
+		return nil, err
+	} else if err := yaml.Unmarshal(k8sSecretYamlBytes, &k8sSecretYamlMap); err != nil {
+		return nil, err
+	} else {
+		delete(k8sSecretYamlMap["metadata"].(map[string]interface{}), "creationTimestamp")
+		return yaml.Marshal(k8sSecretYamlMap)
+	}
+}
+
+func (d *DockerConfigJsonSecret) FromYaml(secretBytes []byte) error {
+	k8sSecret := v1.Secret{}
+	k8sDockerConfigJsonMap := k8sDockerConfigJsonMapType{}
+	if err := yaml.UnmarshalStrict(secretBytes, &k8sSecret); err != nil {
+		return err
+	} else if k8sSecret.TypeMeta.Kind != "Secret" {
+		return errors.New("not a Secret kind")
+	} else if k8sSecret.Type != v1.SecretTypeDockerConfigJson {
+		return errors.New("not a kubernetes.io/dockerconfigjson type")
+	} else if k8sDockerConfigJsonMapBytes, ok := k8sSecret.Data[".dockerconfigjson"]; !ok {
+		return errors.New("secret data is missing a value for the .dockerconfigjson key")
+	} else if err := json.Unmarshal(k8sDockerConfigJsonMapBytes, &k8sDockerConfigJsonMap); err != nil {
+		return err
+	} else {
+		d.Name = k8sSecret.ObjectMeta.Name
+		d.Namespace = k8sSecret.ObjectMeta.Namespace
+		for registry, k8sDockerConfigJson := range k8sDockerConfigJsonMap.Auths {
+			d.Uri = registry
+			d.Username = k8sDockerConfigJson.Username
+			d.Password = k8sDockerConfigJson.Password
+			d.Email = k8sDockerConfigJson.Email
+			break
+		}
+		return nil
+	}
+}

--- a/pkg/api/docker_registry_secret_test.go
+++ b/pkg/api/docker_registry_secret_test.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestDockerConfigJsonSecret(t *testing.T) {
+	dockerConfigJsonSecret := DockerConfigJsonSecret{
+		Name:      "some-name",
+		Namespace: "some-namespace",
+		Uri:       "some-uri",
+		Username:  "some-username",
+		Password:  "some-password",
+		Email:     "some-email",
+	}
+	dockerConfigJsonSecretFromYaml := DockerConfigJsonSecret{}
+	validYamlMap := map[string]interface{}{}
+
+	dockerConfigJsonSecretYamlBytes, err := dockerConfigJsonSecret.ToYaml()
+	dockerConfigJsonMap := map[string]interface{}{}
+	if err != nil {
+		t.Fatalf("error converting secret to yaml: %v", err)
+	} else if err := yaml.Unmarshal(dockerConfigJsonSecretYamlBytes, &validYamlMap); err != nil {
+		t.Fatalf("error unmarshalling yaml string: %v, error: %v", string(dockerConfigJsonSecretYamlBytes), err)
+	} else if validYamlMap["apiVersion"] != "v1" ||
+		validYamlMap["kind"] != "Secret" ||
+		validYamlMap["metadata"].(map[string]interface{})["name"] != dockerConfigJsonSecret.Name ||
+		validYamlMap["metadata"].(map[string]interface{})["namespace"] != dockerConfigJsonSecret.Namespace ||
+		validYamlMap["type"] != "kubernetes.io/dockerconfigjson" {
+		t.Fatalf("error verifying validity of secret yaml: %v", string(dockerConfigJsonSecretYamlBytes))
+	} else if dockerConfigJsonBytesBase64, ok := validYamlMap["data"].(map[string]interface{})[".dockerconfigjson"]; !ok {
+		t.Fatalf("no .dockerconfigjson data key in the secret yaml: %v", string(dockerConfigJsonSecretYamlBytes))
+	} else if dockerConfigJsonBytes, err := base64.StdEncoding.DecodeString(dockerConfigJsonBytesBase64.(string)); err != nil {
+		t.Fatalf("error decoding dockerConfigJsonBytes from base64: %v", err)
+	} else if err := json.Unmarshal(dockerConfigJsonBytes, &dockerConfigJsonMap); err != nil {
+		t.Fatalf("error unmarshalling dockerConfigJson from json: %v", err)
+	} else if dockerConfigJson, ok := dockerConfigJsonMap["auths"].(map[string]interface{})[dockerConfigJsonSecret.Uri]; !ok {
+		t.Fatalf("dockerConfigJson map does not contain data for the registry: %v", dockerConfigJsonSecret.Uri)
+	} else if dockerConfigJson.(map[string]interface{})["username"] != dockerConfigJsonSecret.Username ||
+		dockerConfigJson.(map[string]interface{})["password"] != dockerConfigJsonSecret.Password ||
+		dockerConfigJson.(map[string]interface{})["email"] != dockerConfigJsonSecret.Email {
+		t.Fatal("dockerConfigJson map does not contain expected values")
+	} else {
+		authBase64 := dockerConfigJson.(map[string]interface{})["auth"]
+		if auth, err := base64.StdEncoding.DecodeString(authBase64.(string)); err != nil {
+			t.Fatal("error base64 decoding auth value")
+		} else if string(auth) != fmt.Sprintf("%s:%s", dockerConfigJsonSecret.Username, dockerConfigJsonSecret.Password) {
+			t.Fatal("auth value was not what we expected")
+		}
+	}
+
+	t.Logf("dockerConfigJsonSecretYaml: \n%v\n", string(dockerConfigJsonSecretYamlBytes))
+	if err := dockerConfigJsonSecretFromYaml.FromYaml(dockerConfigJsonSecretYamlBytes); err != nil {
+		t.Fatalf("error reading secret in from yaml: %v", err)
+	} else if !reflect.DeepEqual(dockerConfigJsonSecret, dockerConfigJsonSecretFromYaml) {
+		t.Fatalf("secret: %v does not equal secret: %v", dockerConfigJsonSecret, dockerConfigJsonSecretFromYaml)
+	}
+}

--- a/pkg/api/k8s_secret_marshalling.go
+++ b/pkg/api/k8s_secret_marshalling.go
@@ -1,0 +1,26 @@
+package api
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/yaml"
+)
+
+func K8sSecretToYaml(k8sSecret v1.Secret) ([]byte, error) {
+	k8sSecretYamlMap := map[string]interface{}{}
+	if k8sSecretYamlBytes, err := yaml.Marshal(k8sSecret); err != nil {
+		return nil, err
+	} else if err := yaml.Unmarshal(k8sSecretYamlBytes, &k8sSecretYamlMap); err != nil {
+		return nil, err
+	} else {
+		delete(k8sSecretYamlMap["metadata"].(map[string]interface{}), "creationTimestamp")
+		return yaml.Marshal(k8sSecretYamlMap)
+	}
+}
+
+func K8sSecretFromYaml(k8sSecretBytes []byte) (v1.Secret, error) {
+	k8sSecret := v1.Secret{}
+	if err := yaml.UnmarshalStrict(k8sSecretBytes, &k8sSecret); err != nil {
+		return k8sSecret, err
+	}
+	return k8sSecret, nil
+}


### PR DESCRIPTION
Base functionality for marshalling/unmarshalling docker registry secrets to yaml that looks like this:
```
apiVersion: v1
data:
  .dockerconfigjson: eyJhdXRocyI6eyJzb21lLXVyaSI6eyJ1c2VybmFtZSI6InNvbWUtdXNlcm5hbWUiLCJwYXNzd29yZCI6InNvbWUtcGFzc3dvcmQiLCJlbWFpbCI6InNvbWUtZW1haWwiLCJhdXRoIjoiYzI5dFpTMTFjMlZ5Ym1GdFpUcHpiMjFsTFhCaGMzTjNiM0prIn19fQ==
kind: Secret
metadata:
  name: some-name
  namespace: some-namespace
type: kubernetes.io/dockerconfigjson
```

Note: for now, no encryption