### PR TITLE
Auth docker registry push

### DIFF
--- a/cmd/qliksense/context.go
+++ b/cmd/qliksense/context.go
@@ -120,7 +120,7 @@ qliksense config set-image-registry https://your.private.registry.example.com:50
 			}
 			if password != "" {
 				pullPassword = password
-				pushPassword = username
+				pushPassword = password
 			}
 			if (pullUsername != "" && pushUsername == "") || (pullUsername == "" && pushUsername != "") {
 				return errors.New("if you specify pull credentials, you must specify push credentials as well and vise versa")

--- a/cmd/qliksense/pull_push.go
+++ b/cmd/qliksense/pull_push.go
@@ -49,7 +49,7 @@ func pushQliksenseImages(q *qliksense.Qliksense) *cobra.Command {
 			qConfig := qapi.NewQConfig(q.QliksenseHome)
 			if qcr, err := qConfig.GetCurrentCR(); err != nil {
 				return err
-			} else if registry := qcr.GetImageRegistry(); registry != "" {
+			} else if registry := qcr.GetImageRegistry(); registry == "" {
 				return errors.New("no image registry in config")
 			} else {
 				return q.PushImagesForCurrentCR()

--- a/cmd/qliksense/pull_push.go
+++ b/cmd/qliksense/pull_push.go
@@ -49,10 +49,10 @@ func pushQliksenseImages(q *qliksense.Qliksense) *cobra.Command {
 			qConfig := qapi.NewQConfig(q.QliksenseHome)
 			if qcr, err := qConfig.GetCurrentCR(); err != nil {
 				return err
-			} else if imageRegistry := qcr.GetImageRegistry(); imageRegistry == "" {
+			} else if registry := qcr.GetImageRegistry(); registry != "" {
 				return errors.New("no image registry in config")
 			} else {
-				return q.PushImagesForCurrentCR(imageRegistry)
+				return q.PushImagesForCurrentCR()
 			}
 		},
 	}

--- a/cmd/qliksense/root.go
+++ b/cmd/qliksense/root.go
@@ -147,6 +147,9 @@ func rootCmd(p *qliksense.Qliksense) *cobra.Command {
 	// add the list config command as a sub-command to the app config sub-command
 	configCmd.AddCommand(listContextConfigCmd(p))
 
+	// add set-image-registry command as a sub-command to the app config sub-command
+	configCmd.AddCommand(setImageRegistryCmd(p))
+
 	// add uninstall command
 	cmd.AddCommand(uninstallCmd(p))
 

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a // indirect
 	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
 	golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae // indirect
-	golang.org/x/tools v0.0.0-20200226205201-eb7c56241bdb // indirect
+	golang.org/x/tools v0.0.0-20200227222343-706bc42d1f0d // indirect
 	google.golang.org/genproto v0.0.0-20200128133413-58ce757ed39b // indirect
 	google.golang.org/grpc v1.27.0 // indirect
 	gopkg.in/yaml.v2 v2.2.8

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a // indirect
 	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
 	golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae // indirect
-	golang.org/x/tools v0.0.0-20200225230052-807dcd883420 // indirect
+	golang.org/x/tools v0.0.0-20200226205201-eb7c56241bdb // indirect
 	google.golang.org/genproto v0.0.0-20200128133413-58ce757ed39b // indirect
 	google.golang.org/grpc v1.27.0 // indirect
 	gopkg.in/yaml.v2 v2.2.8

--- a/go.sum
+++ b/go.sum
@@ -1205,6 +1205,8 @@ golang.org/x/tools v0.0.0-20200225230052-807dcd883420 h1:4RJNOV+2rLxMEfr6QIpC7GE
 golang.org/x/tools v0.0.0-20200225230052-807dcd883420/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200226205201-eb7c56241bdb h1:RXjcsi6scaPhM5uXm7JRqP2JibKvbgMqx9zDLDB9voM=
 golang.org/x/tools v0.0.0-20200226205201-eb7c56241bdb/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200227222343-706bc42d1f0d h1:7M9AXzLrJWWGdDYtBblPHBTnHtaN6KKQ98OYb35mLlY=
+golang.org/x/tools v0.0.0-20200227222343-706bc42d1f0d/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -1203,6 +1203,8 @@ golang.org/x/tools v0.0.0-20200224181240-023911ca70b2 h1:L/G4KZvrQn7FWLN/LlulBtB
 golang.org/x/tools v0.0.0-20200224181240-023911ca70b2/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200225230052-807dcd883420 h1:4RJNOV+2rLxMEfr6QIpC7GEv9MjD6ApGXTCLrNF9+eA=
 golang.org/x/tools v0.0.0-20200225230052-807dcd883420/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200226205201-eb7c56241bdb h1:RXjcsi6scaPhM5uXm7JRqP2JibKvbgMqx9zDLDB9voM=
+golang.org/x/tools v0.0.0-20200226205201-eb7c56241bdb/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/qliksense/docker_test.go
+++ b/pkg/qliksense/docker_test.go
@@ -1,16 +1,34 @@
 package qliksense
 
 import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
+	"math/big"
 	"net/http"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/containers/image/v5/copy"
+	"github.com/containers/image/v5/signature"
+	"github.com/containers/image/v5/transports/alltransports"
+	imageTypes "github.com/containers/image/v5/types"
+	"golang.org/x/net/context"
+
+	"github.com/qlik-oss/sense-installer/pkg/api"
 
 	"gopkg.in/yaml.v2"
 )
@@ -28,56 +46,115 @@ func Test_locateDockerRegistryBinary(t *testing.T) {
 	t.Logf("output: %v\n", string(out))
 }
 
-func Test_Pull_Push_noAuth(t *testing.T) {
-	registryURI := "localhost:5555"
-	registry, err := setupRegistryV2At(registryURI, false)
-	if registry != nil {
-		defer registry.Close()
-	}
-	if err != nil {
-		t.Fatalf("unexpected error setting up local registry: %v", err)
-	}
+type clientAuthType byte
 
-	tmpQlikSenseHome, err := ioutil.TempDir("", "tmp-qlik-sense-home-")
-	if err != nil {
-		t.Fatalf("unexpected error creating tmp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpQlikSenseHome)
+const (
+	clientAuthNotProvided clientAuthType = iota
+	clientAuthProvided
+	clientAuthProvidedButIncorrect
+)
 
-	if err := setupQlikSenseHome(t, tmpQlikSenseHome, registryURI); err != nil {
-		t.Fatalf("unexpected error setting up qliksense home: %v", err)
+func Test_Pull_Push_ImagesForCurrentCR(t *testing.T) {
+	var testCases = []struct {
+		name              string
+		registryAuth      bool
+		clientAuth        clientAuthType
+		expectPushSuccess bool
+	}{
+		{
+			name:              "registry does not require auth and we do not provide auth",
+			registryAuth:      false,
+			clientAuth:        clientAuthNotProvided,
+			expectPushSuccess: true,
+		},
+		{
+			name:              "registry does not require auth but we provide auth",
+			registryAuth:      false,
+			clientAuth:        clientAuthProvided,
+			expectPushSuccess: true,
+		},
+		{
+			name:              "registry requires auth but we do not provide auth",
+			registryAuth:      true,
+			clientAuth:        clientAuthNotProvided,
+			expectPushSuccess: false,
+		},
+		{
+			name:              "registry requires auth but we provide wrong auth",
+			registryAuth:      true,
+			clientAuth:        clientAuthProvidedButIncorrect,
+			expectPushSuccess: false,
+		},
+		{
+			name:              "registry requires auth and we provide auth",
+			registryAuth:      true,
+			clientAuth:        clientAuthProvided,
+			expectPushSuccess: true,
+		},
 	}
-	q := &Qliksense{QliksenseHome: tmpQlikSenseHome}
-	var versionOut VersionOutput
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			registryURI := "127.0.0.1:5555"
+			registry, err := setupRegistryV2At(registryURI, testCase.registryAuth)
+			if registry != nil {
+				defer func() {
+					registry.Close()
+					//fmt.Printf("registry stdout:\n%v\n", registry.stdOutBuffer.String())
+					//fmt.Printf("registry stderr:\n%v\n", registry.stdErrBuffer.String())
+				}()
+			}
+			if err != nil {
+				t.Fatalf("unexpected error setting up local registry: %v", err)
+			}
 
-	if err := q.PullImagesForCurrentCR(); err != nil {
-		t.Fatalf("unexpected pull error: %v", err)
-	} else if versionOutBytes, err := ioutil.ReadFile(path.Join(tmpQlikSenseHome, "images", "foo")); err != nil {
-		t.Fatalf("unexpected error reading version file: %v", err)
-	} else if err = yaml.Unmarshal(versionOutBytes, &versionOut); err != nil {
-		t.Fatalf("unexpected error unmarshalling version file: %v", err)
-	} else if len(versionOut.Images) != 1 || versionOut.Images[0] != "alpine:latest" {
-		t.Fatal("did not find alpine:latest in the version file")
-	} else if infos, err := ioutil.ReadDir(path.Join(tmpQlikSenseHome, "images", "index", "alpine", "latest")); err != nil || len(infos) == 0 {
-		t.Fatal("expected images/index/alpine/latest directory to be non-empty")
-	} else if blobInfos, err := ioutil.ReadDir(path.Join(tmpQlikSenseHome, "images", "blobs", "sha256")); err != nil || len(blobInfos) == 0 {
-		t.Fatal("expected images/blobs/sha256 directory to be non-empty")
-	}
+			tmpQlikSenseHome, err := ioutil.TempDir("", "tmp-qlik-sense-home-")
+			if err != nil {
+				t.Fatalf("unexpected error creating tmp dir: %v", err)
+			}
+			defer os.RemoveAll(tmpQlikSenseHome)
 
-	if err := q.PushImagesForCurrentCR(registryURI); err != nil {
-		t.Fatalf("unexpected push error: %v", err)
-	} else if tmpImagesDir, err := ioutil.TempDir("", "tmp-images-"); err != nil {
-		t.Fatalf("unexpected error creating tmp dir: %v", err)
-	} else if err := pullImage(fmt.Sprintf("%s/alpine:latest", registryURI), tmpImagesDir, false); err != nil {
-		t.Fatalf("unexpected error pulling alpine:latest from the local registry: %v", err)
-	} else if infos, err := ioutil.ReadDir(path.Join(tmpImagesDir, "index", "alpine", "latest")); err != nil || len(infos) == 0 {
-		t.Fatal("expected index/alpine/latest directory to be non-empty")
-	} else if blobInfos, err := ioutil.ReadDir(path.Join(tmpImagesDir, "blobs", "sha256")); err != nil || len(blobInfos) == 0 {
-		t.Fatal("expected blobs/sha256 directory to be non-empty")
+			if err := setupQlikSenseHome(t, tmpQlikSenseHome, registry, testCase.clientAuth); err != nil {
+				t.Fatalf("unexpected error setting up qliksense home: %v", err)
+			}
+			q := &Qliksense{QliksenseHome: tmpQlikSenseHome}
+			var versionOut VersionOutput
+
+			if err := q.PullImagesForCurrentCR(); err != nil {
+				t.Fatalf("unexpected pull error: %v", err)
+			} else if versionOutBytes, err := ioutil.ReadFile(path.Join(tmpQlikSenseHome, "images", "foo")); err != nil {
+				t.Fatalf("unexpected error reading version file: %v", err)
+			} else if err = yaml.Unmarshal(versionOutBytes, &versionOut); err != nil {
+				t.Fatalf("unexpected error unmarshalling version file: %v", err)
+			} else if len(versionOut.Images) != 1 || versionOut.Images[0] != "alpine:latest" {
+				t.Fatal("did not find alpine:latest in the version file")
+			} else if infos, err := ioutil.ReadDir(path.Join(tmpQlikSenseHome, "images", "index", "alpine", "latest")); err != nil || len(infos) == 0 {
+				t.Fatal("expected images/index/alpine/latest directory to be non-empty")
+			} else if blobInfos, err := ioutil.ReadDir(path.Join(tmpQlikSenseHome, "images", "blobs", "sha256")); err != nil || len(blobInfos) == 0 {
+				t.Fatal("expected images/blobs/sha256 directory to be non-empty")
+			}
+
+			if testCase.expectPushSuccess {
+				if err := q.PushImagesForCurrentCR(); err != nil {
+					t.Fatalf("unexpected push error: %v", err)
+				} else if tmpImagesDir, err := ioutil.TempDir("", "tmp-images-"); err != nil {
+					t.Fatalf("unexpected error creating tmp dir: %v", err)
+				} else if err := testPullImage(fmt.Sprintf("%s/alpine:latest", registryURI), tmpImagesDir, registry); err != nil {
+					t.Fatalf("unexpected error pulling alpine:latest from the local registry: %v", err)
+				} else if infos, err := ioutil.ReadDir(path.Join(tmpImagesDir, "index", "alpine", "latest")); err != nil || len(infos) == 0 {
+					t.Fatal("expected index/alpine/latest directory to be non-empty")
+				} else if blobInfos, err := ioutil.ReadDir(path.Join(tmpImagesDir, "blobs", "sha256")); err != nil || len(blobInfos) == 0 {
+					t.Fatal("expected blobs/sha256 directory to be non-empty")
+				}
+			} else {
+				if err := q.PushImagesForCurrentCR(); err == nil {
+					t.Fatal("unexpected push success")
+				}
+			}
+		})
 	}
 }
 
-func setupQlikSenseHome(t *testing.T, tmpQlikSenseHome string, registryURI string) error {
+func setupQlikSenseHome(t *testing.T, tmpQlikSenseHome string, registry *testRegistryV2, clientAuth clientAuthType) error {
 	if err := ioutil.WriteFile(path.Join(tmpQlikSenseHome, "config.yaml"), []byte(fmt.Sprintf(`
 apiVersion: config.qlik.com/v1
 kind: QliksenseConfig
@@ -115,8 +192,25 @@ spec:
   manifestsRoot: %s
   rotateKeys: "yes"
   releaseName: qlik-default
-`, version, registryURI, manifestsRootDir)), os.ModePerm); err != nil {
+`, version, registry.url, manifestsRootDir)), os.ModePerm); err != nil {
 		return err
+	}
+
+	if clientAuth == clientAuthProvided || clientAuth == clientAuthProvidedButIncorrect {
+		if registry.username == "" || clientAuth == clientAuthProvidedButIncorrect {
+			registry.username = "bad"
+		}
+		if registry.password == "" || clientAuth == clientAuthProvidedButIncorrect {
+			registry.password = "worse"
+		}
+		qConfig := api.NewQConfig(tmpQlikSenseHome)
+		if err := qConfig.SetPushDockerConfigJsonSecret(&api.DockerConfigJsonSecret{
+			Uri:      registry.url,
+			Username: registry.username,
+			Password: registry.password,
+		}); err != nil {
+			return err
+		}
 	}
 
 	profileDir := path.Join(manifestsRootDir, "manifests", "docker-desktop")
@@ -168,12 +262,14 @@ patches:
 }
 
 type testRegistryV2 struct {
-	cmd      *exec.Cmd
-	url      string
-	dir      string
-	username string
-	password string
-	email    string
+	cmd          *exec.Cmd
+	url          string
+	dir          string
+	username     string
+	password     string
+	email        string
+	stdOutBuffer *bytes.Buffer
+	stdErrBuffer *bytes.Buffer
 }
 
 func locateDockerRegistryBinary() (string, error) {
@@ -196,14 +292,23 @@ func setupRegistryV2At(url string, auth bool) (*testRegistryV2, error) {
 
 	// Wait for registry to be ready to serve requests.
 	for i := 0; i != 50; i++ {
-		if err = reg.Ping(); err == nil {
+		if err := reg.Ping("http"); err == nil {
+			fmt.Print("registry http ping succeeded\n")
 			break
+		} else {
+			fmt.Printf("registry http ping error: %v\n", err)
+		}
+		if err := reg.Ping("https"); err == nil {
+			fmt.Print("registry https ping succeeded\n")
+			break
+		} else {
+			fmt.Printf("registry https ping error: %v\n", err)
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
 
 	if err != nil {
-		return reg, errors.New("Timeout waiting for test registry to become available")
+		return reg, errors.New("timeout waiting for test registry to become available")
 	}
 	return reg, nil
 }
@@ -214,7 +319,7 @@ func newTestRegistryV2At(url string, auth bool) (*testRegistryV2, error) {
 		return nil, err
 	}
 	template := `version: 0.1
-loglevel: debug
+loglevel: info
 storage:
     filesystem:
         rootdirectory: %s
@@ -229,7 +334,23 @@ http:
 		password string
 		email    string
 	)
+	var env []string
 	if auth {
+		if certificate, key, err := getSelfSignedCertAndKey(); err != nil {
+			return nil, err
+		} else {
+			certPath := filepath.Join(tmp, "domain.crt")
+			if err := ioutil.WriteFile(certPath, certificate, os.FileMode(0644)); err != nil {
+				return nil, err
+			}
+			keyPath := filepath.Join(tmp, "domain.key")
+			if err := ioutil.WriteFile(keyPath, key, os.FileMode(0644)); err != nil {
+				return nil, err
+			}
+			env = append(env, fmt.Sprintf("REGISTRY_HTTP_TLS_CERTIFICATE=%v", certPath))
+			env = append(env, fmt.Sprintf("REGISTRY_HTTP_TLS_KEY=%v", keyPath))
+		}
+
 		htpasswdPath := filepath.Join(tmp, "htpasswd")
 		userpasswd := "testuser:$2y$05$sBsSqk0OpSD1uTZkHXc4FeJ0Z70wLQdAX/82UiHuQOKbNbBrzs63m"
 		username = "testuser"
@@ -259,23 +380,34 @@ http:
 		return nil, err
 	}
 	cmd := exec.Command(dockerRegistryBinaryPath, "serve", confPath)
+	cmd.Env = env
+	stdOutBuf, stdErrBuf, err := consumeAndLogOutputs(fmt.Sprintf("registry-%s", url), cmd)
+	if err != nil {
+		return nil, err
+	}
 	if err := cmd.Start(); err != nil {
 		os.RemoveAll(tmp)
 		return nil, err
 	}
 	return &testRegistryV2{
-		cmd:      cmd,
-		url:      url,
-		dir:      tmp,
-		username: username,
-		password: password,
-		email:    email,
+		cmd:          cmd,
+		url:          url,
+		dir:          tmp,
+		username:     username,
+		password:     password,
+		email:        email,
+		stdOutBuffer: stdOutBuf,
+		stdErrBuffer: stdErrBuf,
 	}, nil
 }
 
-func (t *testRegistryV2) Ping() error {
-	// We always ping through HTTP for our test registry.
-	resp, err := http.Get(fmt.Sprintf("http://%s/v2/", t.url))
+func (t *testRegistryV2) Ping(protocol string) error {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	client := &http.Client{Transport: tr}
+
+	resp, err := client.Get(fmt.Sprintf("%v://%s/v2/", protocol, t.url))
 	if err != nil {
 		return err
 	}
@@ -288,4 +420,120 @@ func (t *testRegistryV2) Ping() error {
 func (t *testRegistryV2) Close() {
 	t.cmd.Process.Kill()
 	os.RemoveAll(t.dir)
+}
+
+func consumeAndLogOutputStream(id string, f io.ReadCloser) *bytes.Buffer {
+	buff := &bytes.Buffer{}
+	go func() {
+		defer func() {
+			f.Close()
+			fmt.Fprintf(buff, "[%s]: Closed\n", id)
+		}()
+		buf := make([]byte, 1024)
+		for {
+			fmt.Fprintf(buff, "[%s]: waiting\n", id)
+			n, err := f.Read(buf)
+			fmt.Fprintf(buff, "[%s]: got %d,%#v: %s\n", id, n, err, strings.TrimSuffix(string(buf[:n]), "\n"))
+			if n <= 0 {
+				break
+			}
+		}
+	}()
+	return buff
+}
+
+// consumeAndLogOutputs causes all output to stdout and stderr from an *exec.Cmd to be logged to c
+func consumeAndLogOutputs(id string, cmd *exec.Cmd) (*bytes.Buffer, *bytes.Buffer, error) {
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, nil, err
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, nil, err
+	}
+	return consumeAndLogOutputStream(id+" stdout", stdout), consumeAndLogOutputStream(id+" stderr", stderr), nil
+}
+
+func getSelfSignedCertAndKey() (certificate, key []byte, err error) {
+	priv, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, nil, err
+	}
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, nil, fmt.Errorf("ailed to generate serial number: %s", err)
+	}
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Acme Co"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour * 24),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create certificate: %s", err)
+	}
+	certificate = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+
+	privBytes, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to marshal private key: %v", err)
+	}
+	key = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privBytes})
+
+	return certificate, key, nil
+}
+
+func testPullImage(image, imagesDir string, registry *testRegistryV2) error {
+	srcRef, err := alltransports.ParseImageName(fmt.Sprintf("docker://%v", image))
+	if err != nil {
+		return err
+	}
+	nameTag := getImageNameParts(image)
+	targetDir := filepath.Join(imagesDir, imageIndexDirName, nameTag.name, nameTag.tag)
+	if err := os.MkdirAll(targetDir, os.ModePerm); err != nil {
+		return err
+	}
+
+	destRef, err := alltransports.ParseImageName(fmt.Sprintf("oci:%v", targetDir))
+	if err != nil {
+		return err
+	}
+
+	policyContext, err := signature.NewPolicyContext(&signature.Policy{Default: []signature.PolicyRequirement{signature.NewPRInsecureAcceptAnything()}})
+	if err != nil {
+		return err
+	}
+	defer policyContext.Destroy()
+
+	fmt.Printf("==> Test is pulling image from %v\n", srcRef.StringWithinTransport())
+	sourceCtx := &imageTypes.SystemContext{
+		ArchitectureChoice:          "amd64",
+		OSChoice:                    "linux",
+		DockerInsecureSkipTLSVerify: imageTypes.OptionalBoolTrue,
+	}
+	if registry.username != "" {
+		sourceCtx.DockerAuthConfig = &imageTypes.DockerAuthConfig{
+			Username: registry.username,
+			Password: registry.password,
+		}
+	}
+	if _, err := copy.Image(context.Background(), policyContext, destRef, srcRef, &copy.Options{
+		ReportWriter: os.Stdout,
+		SourceCtx:    sourceCtx,
+		DestinationCtx: &imageTypes.SystemContext{
+			OCISharedBlobDirPath: filepath.Join(imagesDir, imageSharedBlobsDirName),
+		},
+	}); err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/qliksense/docker_test.go
+++ b/pkg/qliksense/docker_test.go
@@ -46,6 +46,15 @@ func Test_locateDockerRegistryBinary(t *testing.T) {
 	t.Logf("output: %v\n", string(out))
 }
 
+func Test_getSelfSignedCertAndKey(t *testing.T) {
+	selfSignedCert, key, err := getSelfSignedCertAndKey()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fmt.Print(string(selfSignedCert))
+	fmt.Print(string(key))
+}
+
 type clientAuthType byte
 
 const (


### PR DESCRIPTION
Self signed cert/key can be generated like so:
```
go test -tags "netgo containers_image_ostree_stub exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp" github.com/qlik-oss/sense-installer/pkg/qliksense -run Test_getSelfSignedCertAndKey -v
```

Then if you set up a directory structure like so: 
```
MacBook-Pro:docker-registry-config dlx$ tree
.
├── domain.crt
├── domain.key
└── htpasswd

0 directories, 3 files
MacBook-Pro:docker-registry-config dlx$ cat domain.crt
-----BEGIN CERTIFICATE-----
MIIE4zCCAsugAwIBAgIQHcVxZ3yNQbNacYuOGaB5ajANBgkqhkiG9w0BAQsFADAS
...
-----END CERTIFICATE-----MacBook-Pro:docker-registry-config dlx$
MacBook-Pro:docker-registry-config dlx$ cat domain.key
-----BEGIN PRIVATE KEY-----
MIIJRQIBADANBgkqhkiG9w0BAQEFAASCCS8wggkrAgEAAoICAQDZ4kvvZsLb8uvT
...
-----END PRIVATE KEY-----MacBook-Pro:docker-registry-config dlx$
MacBook-Pro:docker-registry-config dlx$
MacBook-Pro:docker-registry-config dlx$ cat htpasswd
testuser:$2y$05$sBsSqk0OpSD1uTZkHXc4FeJ0Z70wLQdAX/82UiHuQOKbNbBrzs63mMacBook-Pro:docker-registry-config dlx$
MacBook-Pro:docker-registry-config dlx$
```

Note: `htpasswd` file can be used as is and was generated for username `testuser` and password `testpassword`.

Start image registry from the `docker-registry-config` directory like so:
```
docker run -d \
  -p 5000:5000 \
  --restart=always \
  --name registry \
  -v "$(pwd)":/auth-config \
  -e "REGISTRY_AUTH=htpasswd" \
  -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm" \
  -e REGISTRY_AUTH_HTPASSWD_PATH=/auth-config/htpasswd \
  -e REGISTRY_HTTP_TLS_CERTIFICATE=/auth-config/domain.crt \
  -e REGISTRY_HTTP_TLS_KEY=/auth-config/domain.key \
  registry:2
```

Then set image registry in qliksense config like so:
```
bin/qliksense config set-image-registry localhost:5000 --username testuser --password testpassword
```

Then this will work:
```
bin/qliksense pull ms-3
bin/qliksense push
```