### PR TITLE
Enforcing eula acceptance for all context/CR based commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,11 +46,11 @@ build: clean generate
 .PHONY: test
 test: clean generate
 ifeq ($(shell ${WHICH} docker-registry 2>${DEVNUL}),)
-	$(eval TMP := $(shell mktemp -d))
-	git clone https://github.com/docker/distribution.git $(TMP)/docker-distribution
-	cd $(TMP)/docker-distribution; git checkout -b v2.7.1; make
-	cp $(TMP)/docker-distribution/bin/registry pkg/qliksense/docker-registry
-	-rm -rf $(TMP)/docker-distribution
+	$(eval TMP-docker-distribution := $(shell mktemp -d))
+	git clone https://github.com/docker/distribution.git $(TMP-docker-distribution)/docker-distribution
+	cd $(TMP-docker-distribution)/docker-distribution; git checkout -b v2.7.1; make
+	cp $(TMP-docker-distribution)/docker-distribution/bin/registry pkg/qliksense/docker-registry
+	-rm -rf $(TMP-docker-distribution)
 endif
 	go test -short -count=1 -tags "$(BUILDTAGS)" -v ./...
 	$(MAKE) clean
@@ -91,12 +91,16 @@ clean-packr: packr2
 	cd pkg/qliksense && packr2 clean
 
 get-crds:
-	$(eval TMP := $(shell mktemp -d))
-	git clone https://github.com/qlik-oss/qliksense-operator.git -b master $(TMP)/operator
+ifeq ($(QLIKSENSE_OPERATOR_DIR),)
+	$(eval TMP-operator := $(shell mktemp -d))
+	git clone https://github.com/qlik-oss/qliksense-operator.git -b master $(TMP-operator)/operator
+	$(MAKE) QLIKSENSE_OPERATOR_DIR=$(TMP-operator)/operator get-crds
+	-rm -rf $(TMP-operator)
+else
 	mkdir -p pkg/qliksense/crds/cr
 	mkdir -p pkg/qliksense/crds/crd
 	mkdir -p pkg/qliksense/crds/crd-deploy
-	cp $(TMP)/operator/deploy/*.yaml pkg/qliksense/crds/crd-deploy
-	cp $(TMP)/operator/deploy/crds/*_crd.yaml pkg/qliksense/crds/crd
-	cp $(TMP)/operator/deploy/crds/*_cr.yaml pkg/qliksense/crds/cr
-	-rm -rf $(TMP)/operator
+	cp $(QLIKSENSE_OPERATOR_DIR)/deploy/*.yaml pkg/qliksense/crds/crd-deploy
+	cp $(QLIKSENSE_OPERATOR_DIR)/deploy/crds/*_crd.yaml pkg/qliksense/crds/crd
+	cp $(QLIKSENSE_OPERATOR_DIR)/deploy/crds/*_cr.yaml pkg/qliksense/crds/cr
+endif

--- a/cmd/qliksense/eula.go
+++ b/cmd/qliksense/eula.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	qapi "github.com/qlik-oss/sense-installer/pkg/api"
+	"github.com/qlik-oss/sense-installer/pkg/qliksense"
+)
+
+var eulaEnforced = false
+var eulaText = "EULA text goes here..."
+var eulaPrompt = "Do you accept our EULA? (y/n): "
+var eulaErrorInstruction = "You must enter y/yes to continue"
+
+func isEulaEnforced() bool {
+	return eulaEnforced
+}
+
+func enforceEula(q *qliksense.Qliksense) {
+	if isEulaEnforced() {
+		if qConfig, err := qapi.NewQConfigE(q.QliksenseHome); err != nil {
+			doEnforceEula()
+		} else if qcr, err := qConfig.GetCurrentCR(); err != nil || !qcr.IsEULA() {
+			doEnforceEula()
+		}
+	}
+}
+
+func doEnforceEula() {
+	fmt.Println(eulaText)
+	fmt.Print(eulaPrompt)
+	scanner := bufio.NewScanner(os.Stdin)
+	scanSuccess := scanner.Scan()
+	if !scanSuccess {
+		fmt.Println(eulaErrorInstruction)
+		os.Exit(1)
+	}
+	line := scanner.Text()
+	answer := strings.ToLower(strings.TrimSpace(line))
+	if answer != "y" && answer != "yes" {
+		fmt.Println(eulaErrorInstruction)
+		os.Exit(1)
+	}
+}

--- a/cmd/qliksense/uninstall.go
+++ b/cmd/qliksense/uninstall.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	qapi "github.com/qlik-oss/sense-installer/pkg/api"
 	"github.com/qlik-oss/sense-installer/pkg/qliksense"
 	"github.com/spf13/cobra"
 )
@@ -9,7 +8,7 @@ import (
 func uninstallCmd(q *qliksense.Qliksense) *cobra.Command {
 	c := &cobra.Command{
 		Use:     "uninstall",
-		Short:   "Uninstall the deployed qliksense with release name [ " + qapi.NewQConfig(q.QliksenseHome).Spec.CurrentContext + " ]",
+		Short:   "Uninstall the deployed qliksense.",
 		Long:    `Uninstall the deployed qliksense. By default uninstall the current context`,
 		Example: `qliksense uninstall <context-name>`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/api/apis.go
+++ b/pkg/api/apis.go
@@ -27,16 +27,24 @@ const (
 
 // NewQConfig create QliksenseConfig object from file ~/.qliksense/config.yaml
 func NewQConfig(qsHome string) *QliksenseConfig {
+	qc, err := NewQConfigE(qsHome)
+	if err != nil {
+		fmt.Println("yaml unmarshalling error ", err)
+		os.Exit(1)
+	}
+	return qc
+}
+
+func NewQConfigE(qsHome string) (*QliksenseConfig, error) {
 	configFile := filepath.Join(qsHome, "config.yaml")
 	qc := &QliksenseConfig{}
 
 	err := ReadFromFile(qc, configFile)
 	if err != nil {
-		fmt.Println("yaml unmarshalling error ", err)
-		os.Exit(1)
+		return nil, err
 	}
 	qc.QliksenseHomePath = qsHome
-	return qc
+	return qc, nil
 }
 
 // GetCR create a QliksenseCR object for a particular context
@@ -340,6 +348,10 @@ func (cr *QliksenseCR) IsEULA() bool {
 		}
 	}
 	return false
+}
+
+func (cr *QliksenseCR) SetEULA(value string) {
+	cr.Spec.AddToConfigs("qliksense", "acceptEULA", value)
 }
 
 // GetDecryptedCr it decrypts all the encrypted value and return a new CR

--- a/pkg/qliksense/context_configs.go
+++ b/pkg/qliksense/context_configs.go
@@ -3,13 +3,14 @@ package qliksense
 import (
 	"crypto/rsa"
 	"fmt"
-	"github.com/robfig/cron/v3"
 	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
 	"text/tabwriter"
+
+	"github.com/robfig/cron/v3"
 
 	"github.com/qlik-oss/k-apis/pkg/config"
 
@@ -577,4 +578,14 @@ func (q *Qliksense) SetImageRegistry(registry, pushUsername, pushPassword, pullU
 
 	qliksenseCR.Spec.AddToConfigs("qliksense", imageRegistryConfigKey, registry)
 	return api.WriteToFile(&qliksenseCR, qliksenseContextsFile)
+}
+
+func (q *Qliksense) SetEulaAccepted() error {
+	qConfig := api.NewQConfig(q.QliksenseHome)
+	qcr, err := qConfig.GetCurrentCR()
+	if err != nil {
+		return err
+	}
+	qcr.SetEULA("yes")
+	return qConfig.WriteCurrentContextCR(qcr)
 }

--- a/pkg/qliksense/install.go
+++ b/pkg/qliksense/install.go
@@ -42,7 +42,7 @@ func (q *Qliksense) InstallQK8s(version string, opts *InstallCommandOptions, kee
 	}
 
 	if opts.AcceptEULA != "" {
-		qcr.Spec.AddToConfigs("qliksense", "acceptEULA", opts.AcceptEULA)
+		qcr.SetEULA(opts.AcceptEULA)
 	}
 	if opts.MongoDbUri != "" {
 		qcr.Spec.AddToSecrets("qliksense", "mongoDbUri", opts.MongoDbUri, "")


### PR DESCRIPTION
All commands except help/version will require EULA acceptance if `eulaEnforced` is `true`.

In this open source version `eulaEnforced=false`, so there is no enforcement by default.

In a commercial version, one could add a file in the `main` package with an `init()` function enabling enforcement like so:
```
func init() {
  eulaEnforced = true
  eulaText = "your specific EULA text goes here..."
}
``` 