### PR TITLE
Preflight win error

### DIFF
--- a/pkg/preflight/dns_check.go
+++ b/pkg/preflight/dns_check.go
@@ -32,7 +32,7 @@ spec:
     - textAnalyze:
         checkName: DNS check
         collectorName: spin-up-pod-check-dns
-        fileName: spin-up-pod.txt
+        fileName: spin-up-pod.log
         regex: succeeded
         outcomes:
           - fail:

--- a/pkg/preflight/dns_check.go
+++ b/pkg/preflight/dns_check.go
@@ -15,17 +15,17 @@ apiVersion: troubleshoot.replicated.com/v1beta1
 kind: Preflight
 metadata:
   name: cluster-preflight-checks
-  namespace: {{ . }}
+  namespace: {{ .namespace }}
 spec:
   collectors:
     - run: 
         collectorName: spin-up-pod
-        args: ["-z", "-v", "-w 1", "qnginx001", "80"]
+        args: ["-z", "-v", "-w 1", "{{ .serviceName }}", "80"]
         command: ["nc"]
         image: subfuzion/netcat:latest
         imagePullPolicy: IfNotPresent
         name: spin-up-pod-check-dns
-        namespace: {{ . }}
+        namespace: {{ .namespace }}
         timeout: 30s
 
   analyzers:
@@ -59,8 +59,13 @@ func (qp *QliksensePreflight) CheckDns() error {
 	}
 	api.LogDebugMessage("Temp Yaml file: %s\n", tempYaml.Name())
 
+	appName := "qnginx001"
+	const PreflightChecksDirName = "preflight_checks"
 	b := bytes.Buffer{}
-	err = tmpl.Execute(&b, namespace)
+	err = tmpl.Execute(&b, map[string]string{
+		"namespace":   namespace,
+		"serviceName": appName,
+	})
 	if err != nil {
 		fmt.Println(err)
 		return err
@@ -69,9 +74,6 @@ func (qp *QliksensePreflight) CheckDns() error {
 	tempYaml.WriteString(b.String())
 
 	// creating Kubectl resources
-	appName := "qnginx001"
-	const PreflightChecksDirName = "preflight_checks"
-
 	fmt.Println("Creating resources to run preflight checks")
 
 	// kubectl create deployment

--- a/pkg/preflight/preflight_utils.go
+++ b/pkg/preflight/preflight_utils.go
@@ -21,7 +21,7 @@ type QliksensePreflight struct {
 
 const (
 	// preflight releases have the same version
-	preflightRelease       = "v0.9.26"
+	preflightRelease       = "v0.9.28"
 	preflightLinuxFile     = "preflight_linux_amd64.tar.gz"
 	preflightMacFile       = "preflight_darwin_amd64.tar.gz"
 	preflightWindowsFile   = "preflight_windows_amd64.zip"

--- a/pkg/preflight/preflight_utils.go
+++ b/pkg/preflight/preflight_utils.go
@@ -32,10 +32,12 @@ const (
 var preflightBaseURL = fmt.Sprintf("https://github.com/replicatedhq/troubleshoot/releases/download/%s/", preflightRelease)
 
 func (qp *QliksensePreflight) DownloadPreflight() error {
-	const preflightExecutable = "preflight"
+	preflightExecutable := "preflight"
+	if runtime.GOOS == "windows" {
+		preflightExecutable += ".exe"
+	}
 
 	preflightInstallDir := filepath.Join(qp.Q.QliksenseHome, PreflightChecksDirName)
-	platform := runtime.GOOS
 
 	exists, err := checkInstalled(preflightInstallDir, preflightExecutable)
 	if err != nil {
@@ -60,7 +62,7 @@ func (qp *QliksensePreflight) DownloadPreflight() error {
 	}
 	api.LogDebugMessage("Preflight-checks install Dir: %s exists", preflightInstallDir)
 
-	preflightUrl, preflightFile, err := determinePlatformSpecificUrls(platform)
+	preflightUrl, preflightFile, err := determinePlatformSpecificUrls(runtime.GOOS)
 	if err != nil {
 		err = fmt.Errorf("There was an error when trying to determine platform specific paths")
 		return err

--- a/pkg/preflight/preflight_utils.go
+++ b/pkg/preflight/preflight_utils.go
@@ -145,7 +145,14 @@ func initiateK8sOps(opr, namespace string) error {
 
 func invokePreflight(preflightCommand string, yamlFile *os.File) error {
 	arguments := []string{}
-	arguments = append(arguments, yamlFile.Name(), "--interactive=false")
+	// check for 2nd character is ':' then take file location from after ':'
+	tempYamlName := yamlFile.Name()
+	if tempYamlName[1] == ':' {
+		tempYamlName = tempYamlName[2:]
+		api.LogDebugMessage("This is the Windows yaml file path after modification: %s", tempYamlName)
+	}
+
+	arguments = append(arguments, tempYamlName, "--interactive=false")
 	cmd := exec.Command(preflightCommand, arguments...)
 
 	sterrBuffer := &bytes.Buffer{}

--- a/pkg/preflight/preflight_utils.go
+++ b/pkg/preflight/preflight_utils.go
@@ -146,15 +146,9 @@ func initiateK8sOps(opr, namespace string) error {
 }
 
 func invokePreflight(preflightCommand string, yamlFile *os.File) error {
-	arguments := []string{}
-	// check for 2nd character is ':' then take file location from after ':'
-	tempYamlName := yamlFile.Name()
-	if tempYamlName[1] == ':' {
-		tempYamlName = tempYamlName[2:]
-		api.LogDebugMessage("This is the Windows yaml file path after modification: %s", tempYamlName)
-	}
+	var arguments []string
 
-	arguments = append(arguments, tempYamlName, "--interactive=false")
+	arguments = append(arguments, yamlFile.Name(), "--interactive=false")
 	cmd := exec.Command(preflightCommand, arguments...)
 
 	sterrBuffer := &bytes.Buffer{}


### PR DESCRIPTION
- Fixed a preflight issue with windows where a config yaml file was interpreted as a web link
- Fixed an issue on sense-installer where the latest release of preflight now expects a `.log` file instead of a `.txt` file to collect.

- On windows, `qliksense preflight dns` should work. 
- However, `qliksense preflight k8s-version` will fail: 
```
Minimum Kubernetes version supported: 1.11.0
Client Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.0", GitCommit:"9e991415386e4cf155a24b1da15becaa390438d8", GitTreeState:"clean", BuildDate:"2020-03-25T14:58:59Z", GoVersion:"go1.13.8", Compiler:"gc", Platform:"windows/amd64"}
Server Version: version.Info{Major:"1", Minor:"17", GitVersion:"v1.17.3+k3s1", GitCommit:"5b17a175ce333dfb98cb8391afeb1f34219d9275", GitTreeState:"clean", BuildDate:"2020-02-27T07:28:53Z", GoVersion:"go1.13.8", Compiler:"gc", Platform:"linux/amd64"}
  Running Preflight checks ⠦
--- FAIL: Analyzer Failed
      --- failed to get contents of cluster_version.json: file cluster-info/cluster_version.json was not collected
--- FAIL   cluster-preflight-checks
FAILED
Minimum kubernetes version check completed
```

`qliksense preflight all` will work well, but fail on the `k8s-version` check with the same error as above.
This is a new bug in preflight, I'm working with them to get this resolved as well. Will make another PR with the new preflight version soon after the issue is fixed on their end.