### PR TITLE
troubleshoot-preflight cleaned up and reworked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ pkg/qliksense/qliksense-packr.go
 pkg/qliksense/docker-registry
 /pkg/qliksense/tests
 .DS_Store
+
+.idea/

--- a/cmd/qliksense/preflight.go
+++ b/cmd/qliksense/preflight.go
@@ -34,7 +34,8 @@ func preflightCheckDnsCmd(q *qliksense.Qliksense) *cobra.Command {
 			qp := &preflight.QliksensePreflight{Q: q}
 
 			// Preflight DNS check
-			fmt.Printf("Running preflight DNS check...\n")
+			fmt.Printf("Preflight DNS check\n")
+			fmt.Println("---------------------")
 			namespace, kubeConfigContents, err := initPreflight()
 			if err != nil {
 				fmt.Printf("Preflight DNS check failed\n")
@@ -60,7 +61,8 @@ func preflightCheckK8sVersionCmd(q *qliksense.Qliksense) *cobra.Command {
 			qp := &preflight.QliksensePreflight{Q: q}
 
 			// Preflight Kubernetes minimum version check
-			fmt.Printf("Running preflight kubernetes minimum version check...\n")
+			fmt.Printf("Preflight kubernetes minimum version check\n")
+			fmt.Println("------------------------------------------")
 			namespace, kubeConfigContents, err := initPreflight()
 			if err != nil {
 				fmt.Printf("Preflight kubernetes minimum version check failed\n")
@@ -86,7 +88,7 @@ func preflightAllChecksCmd(q *qliksense.Qliksense) *cobra.Command {
 			qp := &preflight.QliksensePreflight{Q: q}
 
 			// Preflight run all checks
-			fmt.Printf("Running all preflight checks...\n")
+			fmt.Printf("Running all preflight checks\n")
 			namespace, kubeConfigContents, err := initPreflight()
 			if err != nil {
 				fmt.Printf("Preflight checks failed...\n")

--- a/cmd/qliksense/preflight.go
+++ b/cmd/qliksense/preflight.go
@@ -37,9 +37,11 @@ func preflightCheckDnsCmd(q *qliksense.Qliksense) *cobra.Command {
 			fmt.Printf("Running preflight DNS check...\n")
 			namespace, kubeConfigContents, err := initPreflight()
 			if err != nil {
+				fmt.Printf("Preflight DNS check failed\n")
 				log.Fatal(err)
 			}
 			if err = qp.CheckDns(namespace, kubeConfigContents); err != nil {
+				fmt.Printf("Preflight DNS check failed\n")
 				log.Fatal(err)
 			}
 			return nil
@@ -61,9 +63,11 @@ func preflightCheckK8sVersionCmd(q *qliksense.Qliksense) *cobra.Command {
 			fmt.Printf("Running preflight kubernetes minimum version check...\n")
 			namespace, kubeConfigContents, err := initPreflight()
 			if err != nil {
+				fmt.Printf("Preflight kubernetes minimum version check failed\n")
 				log.Fatal(err)
 			}
 			if err = qp.CheckK8sVersion(namespace, kubeConfigContents); err != nil {
+				fmt.Printf("Preflight kubernetes minimum version check failed\n")
 				log.Fatal(err)
 			}
 			return nil
@@ -85,6 +89,7 @@ func preflightAllChecksCmd(q *qliksense.Qliksense) *cobra.Command {
 			fmt.Printf("Running all preflight checks...\n")
 			namespace, kubeConfigContents, err := initPreflight()
 			if err != nil {
+				fmt.Printf("Preflight checks failed...\n")
 				log.Fatal(err)
 			}
 			if err = qp.RunAllPreflightChecks(namespace, kubeConfigContents); err != nil {

--- a/cmd/qliksense/preflight.go
+++ b/cmd/qliksense/preflight.go
@@ -39,7 +39,10 @@ func preflightCheckDnsCmd(q *qliksense.Qliksense) *cobra.Command {
 			if err != nil {
 				log.Fatal(err)
 			}
-			return qp.CheckDns(namespace, kubeConfigContents)
+			if err = qp.CheckDns(namespace, kubeConfigContents); err != nil {
+				log.Fatal(err)
+			}
+			return nil
 		},
 	}
 	return preflightDnsCmd
@@ -60,7 +63,10 @@ func preflightCheckK8sVersionCmd(q *qliksense.Qliksense) *cobra.Command {
 			if err != nil {
 				log.Fatal(err)
 			}
-			return qp.CheckK8sVersion(namespace, kubeConfigContents)
+			if err = qp.CheckK8sVersion(namespace, kubeConfigContents); err != nil {
+				log.Fatal(err)
+			}
+			return nil
 		},
 	}
 	return preflightCheckK8sVersionCmd
@@ -81,7 +87,10 @@ func preflightAllChecksCmd(q *qliksense.Qliksense) *cobra.Command {
 			if err != nil {
 				log.Fatal(err)
 			}
-			return qp.RunAllPreflightChecks(namespace, kubeConfigContents)
+			if err = qp.RunAllPreflightChecks(namespace, kubeConfigContents); err != nil {
+				log.Fatal(err)
+			}
+			return nil
 
 		},
 	}

--- a/docs/preflight_checks.md
+++ b/docs/preflight_checks.md
@@ -29,19 +29,20 @@ The expected output should be similar to the one shown below.
 ```console
 $ qliksense preflight dns
 
-Creating resources to run preflight checks
-deployment.apps/qnginx001 created
-service/qnginx001 created
-pod/qnginx001-6db5fc95c5-s9sl2 condition met
-  Running Preflight checks ⠇
---- PASS DNS check
-      --- DNS check passed
---- PASS   cluster-preflight-checks
-PASS
-
-DNS check completed, cleaning up resources now
-service "qnginx001" deleted
-deployment.extensions "qnginx001" deleted
+Preflight DNS check
+---------------------
+Created deployment "dep-dns-preflight-check"
+Created service "svc-dns-pf-check"
+Created pod: pf-pod-1
+Fetching pod: pf-pod-1
+Fetching pod: pf-pod-1
+Exec-ing into the container...
+Preflight DNS check: PASSED
+Completed preflight DNS check
+Cleaning up resources...
+Deleted pod: pf-pod-1
+Deleted service: svc-dns-pf-check
+Deleted deployment: dep-dns-preflight-check
 
 ```
 
@@ -51,16 +52,14 @@ The command to run this check and the expected similar output are as shown below
 ```console
 $ qliksense preflight k8s-version
 
-Minimum Kubernetes version supported: 1.11.0
-Client Version: version.Info{Major:"1", Minor:"17", GitVersion:"v1.17.3", GitCommit:"06ad960bfd03b39c8310aaf92d1e7c12ce618213", GitTreeState:"clean", BuildDate:"2020-02-13T18:08:14Z", GoVersion:"go1.13.8", Compiler:"gc", Platform:"darwin/amd64"}
-Server Version: version.Info{Major:"1", Minor:"15", GitVersion:"v1.15.5", GitCommit:"20c265fef0741dd71a66480e35bd69f18351daea", GitTreeState:"clean", BuildDate:"2019-10-15T19:07:57Z", GoVersion:"go1.12.10", Compiler:"gc", Platform:"linux/amd64"}
-  Running Preflight checks ⠇
---- PASS Required Kubernetes Version
-      --- Good to go.
---- PASS   cluster-preflight-checks
-PASS
+Preflight kubernetes minimum version check
+------------------------------------------
+Kubernetes API Server version: v1.15.5
+Current K8s Version: 1.15.5
+Current 1.15.5 is greater than minimum required version:1.11.0, hence good to go
+Preflight minimum kubernetes version check: PASSED
+Completed Preflight kubernetes minimum version check
 
-Minimum kubernetes version check completed
 ```
 
 ### Running all checks
@@ -70,31 +69,30 @@ $ qliksense preflight all
 
 Running all preflight checks
 
-Running DNS check...
-Creating resources to run preflight checks
-deployment.apps/qnginx001 created
-service/qnginx001 created
-pod/qnginx001-6db5fc95c5-grwv2 condition met
-  Running Preflight checks ⠇
---- PASS DNS check
-      --- DNS check passed
---- PASS   cluster-preflight-checks
-PASS
+Preflight DNS check
+-------------------
+Created deployment "dep-dns-preflight-check"
+Created service "svc-dns-pf-check"
+Created pod: pf-pod-1
+Fetching pod: pf-pod-1
+Fetching pod: pf-pod-1
+Exec-ing into the container...
+Preflight DNS check: PASSED
+Completed preflight DNS check
+Cleaning up resources...
+Deleted pod: pf-pod-1
+Deleted service: svc-dns-pf-check
+Deleted deployment: dep-dns-preflight-check
 
-DNS check completed, cleaning up resources now
-service "qnginx001" deleted
-deployment.extensions "qnginx001" deleted
+Preflight kubernetes minimum version check
+------------------------------------------
+Kubernetes API Server version: v1.15.5
+Current K8s Version: 1.15.5
+Current 1.15.5 is greater than minimum required version:1.11.0, hence good to go
+Preflight minimum kubernetes version check: PASSED
+Completed Preflight kubernetes minimum version check
 
-Running minimum kubernetes version check...
-Minimum Kubernetes version supported: 1.11.0
-Client Version: version.Info{Major:"1", Minor:"17", GitVersion:"v1.17.3", GitCommit:"06ad960bfd03b39c8310aaf92d1e7c12ce618213", GitTreeState:"clean", BuildDate:"2020-02-13T18:08:14Z", GoVersion:"go1.13.8", Compiler:"gc", Platform:"darwin/amd64"}
-Server Version: version.Info{Major:"1", Minor:"15", GitVersion:"v1.15.5", GitCommit:"20c265fef0741dd71a66480e35bd69f18351daea", GitTreeState:"clean", BuildDate:"2019-10-15T19:07:57Z", GoVersion:"go1.12.10", Compiler:"gc", Platform:"linux/amd64"}
-  Running Preflight checks ⠧
---- PASS Required Kubernetes Version
-      --- Good to go.
---- PASS   cluster-preflight-checks
-PASS
-
-Minimum kubernetes version check completed
+All preflight checks have PASSED
 Completed running all preflight checks
+
 ```

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ replace (
 require (
 	cloud.google.com/go v0.52.0 // indirect
 	cloud.google.com/go/storage v1.5.0 // indirect
+	github.com/Masterminds/semver/v3 v3.0.3
 	github.com/Shopify/ejson v1.2.1
 	github.com/aws/aws-sdk-go v1.28.9 // indirect
 	github.com/bugsnag/bugsnag-go v1.5.3 // indirect
@@ -59,6 +60,7 @@ require (
 	k8s.io/api v0.17.0
 	k8s.io/apimachinery v0.17.0
 	k8s.io/client-go v11.0.0+incompatible
+	k8s.io/kubectl v0.0.0-20191016120415-2ed914427d51
 	sigs.k8s.io/kustomize/api v0.3.2
 	sigs.k8s.io/yaml v1.1.0
 )

--- a/pkg/preflight/all_checks.go
+++ b/pkg/preflight/all_checks.go
@@ -4,13 +4,16 @@ import (
 	"fmt"
 )
 
-func (qp *QliksensePreflight) RunAllPreflightChecks() error {
-	//run all preflight checks
-	fmt.Println("Running all preflight checks")
-	fmt.Printf("\nRunning DNS check...\n")
-	qp.CheckDns()
-	fmt.Printf("\nRunning minimum kubernetes version check...\n")
-	qp.CheckK8sVersion()
+func (qp *QliksensePreflight) RunAllPreflightChecks(namespace string, kubeConfigContents []byte) error {
+
+	// Preflight DNS check
+	fmt.Printf("\nRunning preflight DNS check...\n")
+	qp.CheckDns(namespace, kubeConfigContents)
+
+	// Preflight minimum kuberenetes version check
+	fmt.Printf("\nRunning preflight kubernetes minimum version check...\n")
+	qp.CheckK8sVersion(namespace, kubeConfigContents)
+
 	fmt.Println("Completed running all preflight checks")
 	return nil
 }

--- a/pkg/preflight/all_checks.go
+++ b/pkg/preflight/all_checks.go
@@ -4,18 +4,31 @@ import (
 	"fmt"
 )
 
-func (qp *QliksensePreflight) RunAllPreflightChecks(namespace string, kubeConfigContents []byte) error {
+func (qp *QliksensePreflight) RunAllPreflightChecks(namespace string, kubeConfigContents []byte) {
 
+	checkCount := 0
 	// Preflight DNS check
 	fmt.Printf("\nPreflight DNS check\n")
 	fmt.Println("-------------------")
-	qp.CheckDns(namespace, kubeConfigContents)
+	if err := qp.CheckDns(namespace, kubeConfigContents); err != nil {
+		fmt.Printf("Preflight DNS check: FAILED\n")
+	} else {
+		checkCount++
+	}
 
 	// Preflight minimum kuberenetes version check
 	fmt.Printf("\nPreflight kubernetes minimum version check\n")
 	fmt.Println("------------------------------------------")
-	qp.CheckK8sVersion(namespace, kubeConfigContents)
+	if err := qp.CheckK8sVersion(namespace, kubeConfigContents); err != nil {
+		fmt.Printf("Preflight kubernetes minimum version check: FAILED\n")
+	} else {
+		checkCount++
+	}
 
+	if checkCount == 2 {
+		fmt.Printf("All preflight checks have PASSED\n")
+	} else {
+		fmt.Printf("1 or more preflight checks have FAILED\n")
+	}
 	fmt.Println("Completed running all preflight checks")
-	return nil
 }

--- a/pkg/preflight/all_checks.go
+++ b/pkg/preflight/all_checks.go
@@ -7,11 +7,13 @@ import (
 func (qp *QliksensePreflight) RunAllPreflightChecks(namespace string, kubeConfigContents []byte) error {
 
 	// Preflight DNS check
-	fmt.Printf("\nRunning preflight DNS check...\n")
+	fmt.Printf("\nPreflight DNS check\n")
+	fmt.Println("-------------------")
 	qp.CheckDns(namespace, kubeConfigContents)
 
 	// Preflight minimum kuberenetes version check
-	fmt.Printf("\nRunning preflight kubernetes minimum version check...\n")
+	fmt.Printf("\nPreflight kubernetes minimum version check\n")
+	fmt.Println("------------------------------------------")
 	qp.CheckK8sVersion(namespace, kubeConfigContents)
 
 	fmt.Println("Completed running all preflight checks")

--- a/pkg/preflight/dns_check.go
+++ b/pkg/preflight/dns_check.go
@@ -11,6 +11,7 @@ func (qp *QliksensePreflight) CheckDns(namespace string, kubeConfigContents []by
 	if err != nil {
 		err = fmt.Errorf("Kube config error: %v\n", err)
 		fmt.Print(err)
+		return err
 	}
 
 	// creating deployment

--- a/pkg/preflight/dns_check.go
+++ b/pkg/preflight/dns_check.go
@@ -16,7 +16,7 @@ func (qp *QliksensePreflight) CheckDns(namespace string, kubeConfigContents []by
 
 	// creating deployment
 	depName := "dep-dns-preflight-check"
-	dnsDeployment, err := createDeployment(clientset, namespace, depName, "nginx")
+	dnsDeployment, err := createPfDeployment(clientset, namespace, depName, "nginx")
 	if err != nil {
 		err = fmt.Errorf("Unable to create deployment: %v\n", err)
 		return err
@@ -44,7 +44,7 @@ WAIT:
 
 	// creating service
 	serviceName := "svc-dns-pf-check"
-	dnsService, err := createService(clientset, namespace, serviceName)
+	dnsService, err := createPfService(clientset, namespace, serviceName)
 	if err != nil {
 		err = fmt.Errorf("Unable to create service : %s\n", serviceName)
 		return err
@@ -53,7 +53,7 @@ WAIT:
 
 	// create a pod
 	podName := "pf-pod-1"
-	dnsPod, err := createPod(clientset, namespace, podName, "subfuzion/netcat:latest")
+	dnsPod, err := createPfPod(clientset, namespace, podName, "subfuzion/netcat:latest")
 	if err != nil {
 		err = fmt.Errorf("Unable to create pod : %s\n", podName)
 		return err

--- a/pkg/preflight/dns_check.go
+++ b/pkg/preflight/dns_check.go
@@ -97,9 +97,9 @@ WAIT:
 		//fmt.Printf("stderr: %s\n", stderr)
 
 		if strings.HasSuffix(stdout, "succeeded!") || strings.HasSuffix(stderr, "succeeded!") {
-			fmt.Println("Preflight DNS check: PASS")
+			fmt.Println("Preflight DNS check: PASSED")
 		} else {
-			fmt.Println("Preflight DNS check: FAIL")
+			fmt.Println("Preflight DNS check: FAILED")
 		}
 	}
 

--- a/pkg/preflight/dns_check.go
+++ b/pkg/preflight/dns_check.go
@@ -6,6 +6,11 @@ import (
 	"time"
 )
 
+const (
+	nginxImage  = "nginx"
+	netcatImage = "subfuzion/netcat:latest"
+)
+
 func (qp *QliksensePreflight) CheckDns(namespace string, kubeConfigContents []byte) error {
 	clientset, clientConfig, err := getK8SClientSet(kubeConfigContents, "")
 	if err != nil {
@@ -16,7 +21,7 @@ func (qp *QliksensePreflight) CheckDns(namespace string, kubeConfigContents []by
 
 	// creating deployment
 	depName := "dep-dns-preflight-check"
-	dnsDeployment, err := createPreflightTestDeployment(clientset, namespace, depName, "nginx")
+	dnsDeployment, err := createPreflightTestDeployment(clientset, namespace, depName, nginxImage)
 	if err != nil {
 		err = fmt.Errorf("Unable to create deployment: %v\n", err)
 		return err
@@ -53,7 +58,7 @@ WAIT:
 
 	// create a pod
 	podName := "pf-pod-1"
-	dnsPod, err := createPreflightTestPod(clientset, namespace, podName, "subfuzion/netcat:latest")
+	dnsPod, err := createPreflightTestPod(clientset, namespace, podName, netcatImage)
 	if err != nil {
 		err = fmt.Errorf("Unable to create pod : %s\n", podName)
 		return err

--- a/pkg/preflight/dns_check.go
+++ b/pkg/preflight/dns_check.go
@@ -16,7 +16,7 @@ func (qp *QliksensePreflight) CheckDns(namespace string, kubeConfigContents []by
 
 	// creating deployment
 	depName := "dep-dns-preflight-check"
-	dnsDeployment, err := createPfDeployment(clientset, namespace, depName, "nginx")
+	dnsDeployment, err := createPreflightTestDeployment(clientset, namespace, depName, "nginx")
 	if err != nil {
 		err = fmt.Errorf("Unable to create deployment: %v\n", err)
 		return err
@@ -44,7 +44,7 @@ WAIT:
 
 	// creating service
 	serviceName := "svc-dns-pf-check"
-	dnsService, err := createPfService(clientset, namespace, serviceName)
+	dnsService, err := createPreflightTestService(clientset, namespace, serviceName)
 	if err != nil {
 		err = fmt.Errorf("Unable to create service : %s\n", serviceName)
 		return err
@@ -53,7 +53,7 @@ WAIT:
 
 	// create a pod
 	podName := "pf-pod-1"
-	dnsPod, err := createPfPod(clientset, namespace, podName, "subfuzion/netcat:latest")
+	dnsPod, err := createPreflightTestPod(clientset, namespace, podName, "subfuzion/netcat:latest")
 	if err != nil {
 		err = fmt.Errorf("Unable to create pod : %s\n", podName)
 		return err
@@ -103,7 +103,8 @@ WAIT:
 		}
 	}
 
-	fmt.Println("Completed preflight DNS check.\n")
+	fmt.Println("Completed preflight DNS check")
+	fmt.Println("Cleaning up resources...")
 
 	return nil
 }

--- a/pkg/preflight/preflight_utils.go
+++ b/pkg/preflight/preflight_utils.go
@@ -93,7 +93,7 @@ func getK8SClientSet(kubeconfig []byte, contextName string) (*kubernetes.Clients
 	return clientset, clientConfig, nil
 }
 
-func createDeployment(clientset *kubernetes.Clientset, namespace string, depName string, imageName string) (*appsv1.Deployment, error) {
+func createPfDeployment(clientset *kubernetes.Clientset, namespace string, depName string, imageName string) (*appsv1.Deployment, error) {
 	deploymentsClient := clientset.AppsV1().Deployments(namespace)
 	deployment := &appsv1.Deployment{
 		ObjectMeta: v1.ObjectMeta{
@@ -178,7 +178,7 @@ func deleteDeployment(clientset *kubernetes.Clientset, namespace, name string) {
 	fmt.Printf("Deleted deployment: %s\n", name)
 }
 
-func createService(clientset *kubernetes.Clientset, namespace string, svcName string) (*apiv1.Service, error) {
+func createPfService(clientset *kubernetes.Clientset, namespace string, svcName string) (*apiv1.Service, error) {
 	//fmt.Println("Creating Service...")
 	iptr := int32Ptr(80)
 	servicesClient := clientset.CoreV1().Services(namespace)
@@ -263,7 +263,7 @@ func deletePod(clientset *kubernetes.Clientset, namespace, name string) error {
 	return nil
 }
 
-func createPod(clientset *kubernetes.Clientset, namespace string, podName string, imageName string) (*apiv1.Pod, error) {
+func createPfPod(clientset *kubernetes.Clientset, namespace string, podName string, imageName string) (*apiv1.Pod, error) {
 	// build the pod definition we want to deploy
 	pod := &apiv1.Pod{
 		ObjectMeta: v1.ObjectMeta{

--- a/pkg/preflight/preflight_utils.go
+++ b/pkg/preflight/preflight_utils.go
@@ -93,7 +93,7 @@ func getK8SClientSet(kubeconfig []byte, contextName string) (*kubernetes.Clients
 	return clientset, clientConfig, nil
 }
 
-func createPfDeployment(clientset *kubernetes.Clientset, namespace string, depName string, imageName string) (*appsv1.Deployment, error) {
+func createPreflightTestDeployment(clientset *kubernetes.Clientset, namespace string, depName string, imageName string) (*appsv1.Deployment, error) {
 	deploymentsClient := clientset.AppsV1().Deployments(namespace)
 	deployment := &appsv1.Deployment{
 		ObjectMeta: v1.ObjectMeta{
@@ -142,7 +142,7 @@ func createPfDeployment(clientset *kubernetes.Clientset, namespace string, depNa
 		fmt.Println(err)
 		return nil, err
 	}
-	fmt.Printf("Created deployment %q.\n", result.GetObjectMeta().GetName())
+	fmt.Printf("Created deployment %q\n", result.GetObjectMeta().GetName())
 
 	return deployment, nil
 }
@@ -178,7 +178,7 @@ func deleteDeployment(clientset *kubernetes.Clientset, namespace, name string) {
 	fmt.Printf("Deleted deployment: %s\n", name)
 }
 
-func createPfService(clientset *kubernetes.Clientset, namespace string, svcName string) (*apiv1.Service, error) {
+func createPreflightTestService(clientset *kubernetes.Clientset, namespace string, svcName string) (*apiv1.Service, error) {
 	//fmt.Println("Creating Service...")
 	iptr := int32Ptr(80)
 	servicesClient := clientset.CoreV1().Services(namespace)
@@ -210,7 +210,7 @@ func createPfService(clientset *kubernetes.Clientset, namespace string, svcName 
 		fmt.Println(err)
 		return nil, err
 	}
-	fmt.Printf("Created service %q.\n", result.GetObjectMeta().GetName())
+	fmt.Printf("Created service %q\n", result.GetObjectMeta().GetName())
 
 	return service, nil
 }
@@ -263,7 +263,7 @@ func deletePod(clientset *kubernetes.Clientset, namespace, name string) error {
 	return nil
 }
 
-func createPfPod(clientset *kubernetes.Clientset, namespace string, podName string, imageName string) (*apiv1.Pod, error) {
+func createPreflightTestPod(clientset *kubernetes.Clientset, namespace string, podName string, imageName string) (*apiv1.Pod, error) {
 	// build the pod definition we want to deploy
 	pod := &apiv1.Pod{
 		ObjectMeta: v1.ObjectMeta{

--- a/pkg/preflight/preflight_utils_test.go
+++ b/pkg/preflight/preflight_utils_test.go
@@ -20,7 +20,7 @@ func Test_initiateK8sOps(t *testing.T) {
 			name: "valid case",
 			args: args{
 				opr:       fmt.Sprintf("version"),
-				namespace: "ash-ns",
+				namespace: "test-ns",
 			},
 			wantErr: false,
 		},
@@ -28,7 +28,7 @@ func Test_initiateK8sOps(t *testing.T) {
 			name: "invalid case",
 			args: args{
 				opr:       fmt.Sprintf("versions"),
-				namespace: "ash-ns",
+				namespace: "test-ns",
 			},
 			wantErr: true,
 		},
@@ -37,53 +37,6 @@ func Test_initiateK8sOps(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := initiateK8sOps(tt.args.opr, tt.args.namespace); (err != nil) != tt.wantErr {
 				t.Errorf("initiateK8sOps() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
-
-func Test_determinePlatformSpecificUrls(t *testing.T) {
-	type args struct {
-		platform string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    string
-		want1   string
-		wantErr bool
-	}{
-		{
-			name: "valid platform",
-			args: args{
-				platform: "windows",
-			},
-			want:    fmt.Sprintf("%s%s", preflightBaseURL, preflightWindowsFile),
-			want1:   preflightWindowsFile,
-			wantErr: false,
-		},
-		{
-			name: "invalid platform",
-			args: args{
-				platform: "unix",
-			},
-			want:    "",
-			want1:   "",
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, got1, err := determinePlatformSpecificUrls(tt.args.platform)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("determinePlatformSpecificUrls() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("determinePlatformSpecificUrls() got = %v, want %v", got, tt.want)
-			}
-			if got1 != tt.want1 {
-				t.Errorf("determinePlatformSpecificUrls() got1 = %v, want %v", got1, tt.want1)
 			}
 		})
 	}

--- a/pkg/preflight/version_check.go
+++ b/pkg/preflight/version_check.go
@@ -2,7 +2,6 @@ package preflight
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/Masterminds/semver/v3"
 	"k8s.io/apimachinery/pkg/version"
@@ -48,9 +47,11 @@ func (qp *QliksensePreflight) CheckK8sVersion(namespace string, kubeConfigConten
 
 	if currentVersion.GreaterThan(minK8sVersionSemver) {
 		//fmt.Printf("\n\nCurrent %s Component version: %s is less than minimum required version:%s\n", component, currentComponentVersion, componentVersionFromDependenciesYaml)
-		log.Printf("Current %s is greater than minimum required version:%s, hence good to go\n", currentVersion, minK8sVersionSemver)
+		fmt.Printf("Current %s is greater than minimum required version:%s, hence good to go\n", currentVersion, minK8sVersionSemver)
+		fmt.Println("Preflight minimum kubernetes version check: PASS")
 	} else {
-		log.Printf("Current %s is less than minimum required version:%s\n", currentVersion, minK8sVersionSemver)
+		fmt.Printf("Current %s is less than minimum required version:%s\n", currentVersion, minK8sVersionSemver)
+		fmt.Println("Preflight minimum kubernetes version check: FAIL")
 	}
 	fmt.Printf("Completed Preflight kubernetes minimum version check\n\n")
 	return nil

--- a/pkg/preflight/version_check.go
+++ b/pkg/preflight/version_check.go
@@ -48,10 +48,10 @@ func (qp *QliksensePreflight) CheckK8sVersion(namespace string, kubeConfigConten
 	if currentVersion.GreaterThan(minK8sVersionSemver) {
 		//fmt.Printf("\n\nCurrent %s Component version: %s is less than minimum required version:%s\n", component, currentComponentVersion, componentVersionFromDependenciesYaml)
 		fmt.Printf("Current %s is greater than minimum required version:%s, hence good to go\n", currentVersion, minK8sVersionSemver)
-		fmt.Println("Preflight minimum kubernetes version check: PASS")
+		fmt.Println("Preflight minimum kubernetes version check: PASSED")
 	} else {
 		fmt.Printf("Current %s is less than minimum required version:%s\n", currentVersion, minK8sVersionSemver)
-		fmt.Println("Preflight minimum kubernetes version check: FAIL")
+		fmt.Println("Preflight minimum kubernetes version check: FAILED")
 	}
 	fmt.Printf("Completed Preflight kubernetes minimum version check\n\n")
 	return nil

--- a/pkg/preflight/version_check.go
+++ b/pkg/preflight/version_check.go
@@ -1,84 +1,57 @@
 package preflight
 
 import (
-	"bytes"
 	"fmt"
-	"io/ioutil"
-	"path/filepath"
-	"text/template"
+	"log"
 
-	"github.com/qlik-oss/sense-installer/pkg/api"
+	"github.com/Masterminds/semver/v3"
+	"k8s.io/apimachinery/pkg/version"
 )
 
 const minK8sVersion = "1.11.0"
-const checkVersionYAML = `
-apiVersion: troubleshoot.replicated.com/v1beta1
-kind: Preflight
-metadata:
-  name: cluster-preflight-checks
-  namespace: {{ .namespace }}
-spec:
-  analyzers:
-    - clusterVersion:
-        outcomes:
-          - fail:
-              when: "< {{ .minK8sVersion }}"
-              message: The application requires at least Kubernetes {{ .minK8sVersion }} or later.
-              uri: https://www.kubernetes.io
-          - pass:
-              when: ">= {{ .minK8sVersion }}"
-              message: Good to go.
-`
 
-func (qp *QliksensePreflight) CheckK8sVersion() error {
-	// retrieve namespace
-	namespace := api.GetKubectlNamespace()
+func (qp *QliksensePreflight) CheckK8sVersion(namespace string, kubeConfigContents []byte) error {
 
-	api.LogDebugMessage("Namespace: %s\n", namespace)
+	var currentVersion *semver.Version
 
-	tmpl, err := template.New("checkVersionYAML").Parse(checkVersionYAML)
+	clientset, _, err := getK8SClientSet(kubeConfigContents, "")
 	if err != nil {
-		fmt.Printf("cannot parse template: %v", err)
+		err = fmt.Errorf("Unable to create clientset: %v\n", err)
 		return err
 	}
-	tempYaml, err := ioutil.TempFile("", "")
-	if err != nil {
-		fmt.Printf("cannot create file: %v", err)
+	var serverVersion *version.Info
+	if err := retryOnError(func() (err error) {
+		serverVersion, err = clientset.ServerVersion()
+		return err
+	}); err != nil {
+		err = fmt.Errorf("Unable to get server version: %v\n", err)
+		//fmt.Println(err)
 		return err
 	}
-	api.LogDebugMessage("Temp Yaml file: %s\n", tempYaml.Name())
+	fmt.Printf("Kubernetes API Server version: %s\n", serverVersion.String())
 
-	b := bytes.Buffer{}
-	err = tmpl.Execute(&b, map[string]string{
-		"namespace":     namespace,
-		"minK8sVersion": minK8sVersion,
-	})
+	// Compare K8s version on the cluster with minimum supported k8s version
+	currentVersion, err = semver.NewVersion(serverVersion.String())
 	if err != nil {
+		err = fmt.Errorf("Unable to convert server version into semver version: %v\n", err)
+		//fmt.Println(err)
+		return err
+	}
+	fmt.Printf("Current K8s Version: %v\n", currentVersion)
+
+	minK8sVersionSemver, err := semver.NewVersion(minK8sVersion)
+	if err != nil {
+		err = fmt.Errorf("Unable to convert minimum Kubernetes version into semver version:%v\n", err)
 		fmt.Println(err)
 		return err
 	}
 
-	tempYaml.WriteString(b.String())
-	//api.LogDebugMessage("Temp yaml contents: %s", b.String())
-	fmt.Printf("Minimum Kubernetes version supported: %s\n", minK8sVersion)
-
-	// current kubectl version
-	opr := fmt.Sprintf("version")
-	err = initiateK8sOps(opr, namespace)
-	if err != nil {
-		fmt.Println(err)
-		return err
+	if currentVersion.GreaterThan(minK8sVersionSemver) {
+		//fmt.Printf("\n\nCurrent %s Component version: %s is less than minimum required version:%s\n", component, currentComponentVersion, componentVersionFromDependenciesYaml)
+		log.Printf("Current %s is greater than minimum required version:%s, hence good to go\n", currentVersion, minK8sVersionSemver)
+	} else {
+		log.Printf("Current %s is less than minimum required version:%s\n", currentVersion, minK8sVersionSemver)
 	}
-
-	// call preflight
-	preflightCommand := filepath.Join(qp.Q.QliksenseHome, PreflightChecksDirName, preflightFileName)
-
-	err = invokePreflight(preflightCommand, tempYaml)
-	if err != nil {
-		fmt.Println(err)
-		return err
-	}
-
-	fmt.Println("Minimum kubernetes version check completed")
+	fmt.Printf("Completed Preflight kubernetes minimum version check\n\n")
 	return nil
 }


### PR DESCRIPTION
As part of this PR:
- Removed troubleshoot-preflight from the sense-installer repo 
- Crafted preflight checks using client-go apis
- Preflight check for DNS and minimum kubernetes version done

Commands:
```
$qliksense preflight dns
$qliksense preflight k8s-version
$qliksense preflight all
```

Output:
```
$qliksense preflight all

Running all preflight checks

Preflight DNS check
-------------------
Created deployment "dep-dns-preflight-check"
Created service "svc-dns-pf-check"
Created pod: pf-pod-1
Fetching pod: pf-pod-1
Fetching pod: pf-pod-1
Exec-ing into the container...
Preflight DNS check: PASSED
Completed preflight DNS check
Cleaning up resources...
Deleted pod: pf-pod-1
Deleted service: svc-dns-pf-check
Deleted deployment: dep-dns-preflight-check

Preflight kubernetes minimum version check
------------------------------------------
Kubernetes API Server version: v1.15.5
Current K8s Version: 1.15.5
Current 1.15.5 is greater than minimum required version:1.11.0, hence good to go
Preflight minimum kubernetes version check: PASSED
Completed Preflight kubernetes minimum version check

All preflight checks PASSED
Completed running all preflight checks
```