### PR TITLE
fix pull

### DIFF
--- a/cmd/qliksense/pull_push.go
+++ b/cmd/qliksense/pull_push.go
@@ -20,28 +20,7 @@ func pullQliksenseImages(q *qliksense.Qliksense) *cobra.Command {
 			if err != nil {
 				return err
 			}
-
-			qConfig := qapi.NewQConfig(q.QliksenseHome)
-			if version == "" {
-				if qcr, err := qConfig.GetCurrentCR(); err != nil {
-					return err
-				} else {
-					version = qcr.GetLabelFromCr("version")
-				}
-			}
-
-			if version != "" {
-				if !qConfig.IsRepoExistForCurrent(version) {
-					if err := q.FetchQK8s(version); err != nil {
-						return err
-					}
-				}
-				if err := qConfig.SwitchCurrentCRToVersionAndProfile(version, opts.Profile); err != nil {
-					return err
-				}
-			}
-
-			return q.PullImagesForCurrentCR()
+			return q.PullImages(version, opts.Profile)
 		},
 	}
 	f := cmd.Flags()

--- a/pkg/api/apis.go
+++ b/pkg/api/apis.go
@@ -133,6 +133,17 @@ func (qc *QliksenseConfig) GetCRFilePath(contextName string) string {
 	}
 	return crFilePath
 }
+
+func (cr *QliksenseCR) IsRepoExist() bool {
+	if cr.Spec.ManifestsRoot == "" {
+		return false
+	}
+	if _, err := os.Lstat(cr.Spec.ManifestsRoot); err != nil {
+		return false
+	}
+	return true
+}
+
 func (qc *QliksenseConfig) IsRepoExist(contextName, version string) bool {
 	if _, err := os.Lstat(qc.BuildRepoPathForContext(contextName, version)); err != nil {
 		return false

--- a/pkg/api/context_apis.go
+++ b/pkg/api/context_apis.go
@@ -62,11 +62,8 @@ func (qliksenseConfig *QliksenseConfig) AddBaseQliksenseConfigs(defaultQliksense
 func (qliksenseConfig *QliksenseConfig) SwitchCurrentCRToVersionAndProfile(version, profile string) error {
 	if qcr, err := qliksenseConfig.GetCurrentCR(); err != nil {
 		return err
-	} else if qcr.Spec.ManifestsRoot != "" && version != "" {
-		qcr.GetLabelFromCr("version")
 	} else {
 		versionManifestRoot := qliksenseConfig.BuildCurrentManifestsRoot(version)
-
 		if (qcr.Spec.ManifestsRoot != versionManifestRoot) || (profile != "" && qcr.Spec.Profile != profile) || (qcr.GetLabelFromCr("version") != version) {
 			qcr.Spec.ManifestsRoot = versionManifestRoot
 			if profile != "" {

--- a/pkg/api/context_apis.go
+++ b/pkg/api/context_apis.go
@@ -62,8 +62,11 @@ func (qliksenseConfig *QliksenseConfig) AddBaseQliksenseConfigs(defaultQliksense
 func (qliksenseConfig *QliksenseConfig) SwitchCurrentCRToVersionAndProfile(version, profile string) error {
 	if qcr, err := qliksenseConfig.GetCurrentCR(); err != nil {
 		return err
+	} else if qcr.Spec.ManifestsRoot != "" && version != "" {
+		qcr.GetLabelFromCr("version")
 	} else {
 		versionManifestRoot := qliksenseConfig.BuildCurrentManifestsRoot(version)
+
 		if (qcr.Spec.ManifestsRoot != versionManifestRoot) || (profile != "" && qcr.Spec.Profile != profile) || (qcr.GetLabelFromCr("version") != version) {
 			qcr.Spec.ManifestsRoot = versionManifestRoot
 			if profile != "" {

--- a/pkg/qliksense/docker.go
+++ b/pkg/qliksense/docker.go
@@ -37,7 +37,7 @@ func (q *Qliksense) PullImages(version, profile string) error {
 	}
 	qcr, err := qConfig.GetCurrentCR()
 	if err != nil {
-		return nil
+		return err
 	}
 	if !qcr.IsRepoExist() {
 		return errors.New("ManifestsRoot not found")

--- a/pkg/qliksense/docker.go
+++ b/pkg/qliksense/docker.go
@@ -1,6 +1,7 @@
 package qliksense
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -26,6 +27,29 @@ const (
 	imageIndexDirName       = "index"
 	imageSharedBlobsDirName = "blobs"
 )
+
+func (q *Qliksense) PullImages(version, profile string) error {
+	qConfig := qapi.NewQConfig(q.QliksenseHome)
+	if version != "" {
+		if err := q.FetchQK8s(version); err != nil {
+			return err
+		}
+	}
+	qcr, err := qConfig.GetCurrentCR()
+	if err != nil {
+		return nil
+	}
+	if !qcr.IsRepoExist() {
+		return errors.New("ManifestsRoot not found")
+	}
+	if profile != "" {
+		qcr.Spec.Profile = profile
+		if e := qConfig.WriteCR(qcr); e != nil {
+			return e
+		}
+	}
+	return q.PullImagesForCurrentCR()
+}
 
 // PullImages ...
 func (q *Qliksense) PullImagesForCurrentCR() error {


### PR DESCRIPTION
User Actions 1:
`qliksense pull v0.0.6`. => set current cr to v0.0.6 and manifestroot set to ~/.qliksense/...... and pull images
`qliksense config set manifestsRoot=/bla/bla`
`qliksense pull` => pull images based on the new manifests root
`qliksense pull v0.0.2` => set current cr to v0.0.2 and manifestroot set to ~/.qliksense/...... and pull images

Signed-off-by: Foysal Iqbal <mqb@qlik.com>