### PR TITLE
add first version of editor

### DIFF
--- a/cmd/qliksense/config.go
+++ b/cmd/qliksense/config.go
@@ -42,3 +42,20 @@ func configViewCmd(q *qliksense.Qliksense) *cobra.Command {
 	}
 	return c
 }
+
+func configEditCmd(q *qliksense.Qliksense) *cobra.Command {
+	c := &cobra.Command{
+		Use:   "edit [context-name]",
+		Short: "Edit the context cr",
+		Long: `edit the context cr. if no context name provided default context will be edited
+		It will open the vim editor unless KUBE_EDITOR is defined`,
+		Example: `qliksense config edit [context-name]`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 1 {
+				return q.EditCR(args[0])
+			}
+			return q.EditCR("")
+		},
+	}
+	return c
+}

--- a/cmd/qliksense/root.go
+++ b/cmd/qliksense/root.go
@@ -190,6 +190,8 @@ func rootCmd(p *qliksense.Qliksense) *cobra.Command {
 	// add clean-config-repo-patches command as a sub-command to the app config sub-command
 	configCmd.AddCommand(cleanConfigRepoPatchesCmd(p))
 
+	// open editor for config
+	configCmd.AddCommand(configEditCmd(p))
 	// add uninstall command
 	cmd.AddCommand(uninstallCmd(p))
 

--- a/pkg/qliksense/config.go
+++ b/pkg/qliksense/config.go
@@ -175,7 +175,7 @@ func (q *Qliksense) EditCR(contextName string) error {
 		contextName = cr.GetName()
 	}
 	crFilePath := qConfig.GetCRFilePath(contextName)
-	tempFile, err := ioutil.TempFile("", "mycr.yaml")
+	tempFile, err := ioutil.TempFile("", "*.yaml")
 	if err != nil {
 		return err
 	}

--- a/pkg/qliksense/config.go
+++ b/pkg/qliksense/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
@@ -162,4 +163,55 @@ func (q *Qliksense) getCurrentCrDependentResourceAsString() (string, error) {
 	}
 	crString.WriteString("\n---\n")
 	return crString.String(), nil
+}
+
+func (q *Qliksense) EditCR(contextName string) error {
+	qConfig := qapi.NewQConfig(q.QliksenseHome)
+	if contextName == "" {
+		cr, err := qConfig.GetCurrentCR()
+		if err != nil {
+			return err
+		}
+		contextName = cr.GetName()
+	}
+	crFilePath := qConfig.GetCRFilePath(contextName)
+	tempFile, err := ioutil.TempFile("", "mycr.yaml")
+	if err != nil {
+		return err
+	}
+	crContent, err := ioutil.ReadFile(crFilePath)
+	if err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(tempFile.Name(), crContent, os.ModePerm); err != nil {
+		return nil
+	}
+	cmd := exec.Command(getKubeEditorTool(), tempFile.Name())
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	err = cmd.Run()
+	if err != nil {
+		return err
+	}
+	newCr, err := qapi.GetCRObject(tempFile.Name())
+	if err != nil {
+		return errors.New("cannot save the cr. Someting wrong in the file format. It is not saved\n" + err.Error())
+	}
+	oldCr, err := qapi.GetCRObject(crFilePath)
+
+	if oldCr.GetName() != newCr.GetName() {
+		return errors.New("cr name cannot be chagned")
+	}
+	if newCr.Validate() {
+		return qConfig.WriteCR(newCr)
+	}
+	return nil
+}
+
+func getKubeEditorTool() string {
+	editor := os.Getenv("KUBE_EDITOR")
+	if editor == "" {
+		editor = "vim"
+	}
+	return editor
 }


### PR DESCRIPTION
New command
`qliksense config edit`. // open the current context in the editor to edit
`qliksense config edit mycontext` // open the mycontext in the editor to edit
it will open the vim editor unless KUBE_EDITOR environment is set to something else
 - context name cannot be changed
 - assume vim is installed on the system unless KUBE_EDITOR is set

TODO:
 - handle secrets editing in the cr
 - find system default editor
 - make it work for windows
Signed-off-by: Foysal Iqbal <mqb@qlik.com>