### PR TITLE
Pulling/pushing GitOps and Preflight images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,8 @@ build: clean generate
 	go build -ldflags '$(LDFLAGS)' -tags "$(BUILDTAGS)" -o $(BINDIR)/$(MIXIN)$(FILE_EXT) ./cmd/$(MIXIN)
 	$(MAKE) clean
 
-.PHONY: test
-test: clean generate
+.PHONY: test-setup
+test-setup: clean generate
 ifeq ($(shell ${WHICH} docker-registry 2>${DEVNUL}),)
 	$(eval TMP-docker-distribution := $(shell mktemp -d))
 	git clone https://github.com/docker/distribution.git $(TMP-docker-distribution)/docker-distribution
@@ -52,7 +52,15 @@ ifeq ($(shell ${WHICH} docker-registry 2>${DEVNUL}),)
 	cp $(TMP-docker-distribution)/docker-distribution/bin/registry pkg/qliksense/docker-registry
 	-rm -rf $(TMP-docker-distribution)
 endif
+
+.PHONY: test-short
+test-short: test-setup
 	go test -short -count=1 -tags "$(BUILDTAGS)" -v ./...
+	$(MAKE) clean
+
+.PHONY: test
+test: test-setup
+	go test -count=1 -tags "$(BUILDTAGS)" -v ./...
 	$(MAKE) clean
 
 xbuild-all: clean generate

--- a/cmd/qliksense/root.go
+++ b/cmd/qliksense/root.go
@@ -12,7 +12,6 @@ import (
 	"github.com/mitchellh/go-homedir"
 	"github.com/qlik-oss/sense-installer/pkg"
 	"github.com/qlik-oss/sense-installer/pkg/api"
-	"github.com/qlik-oss/sense-installer/pkg/preflight"
 	"github.com/qlik-oss/sense-installer/pkg/qliksense"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -101,7 +100,7 @@ func getRootCmd(p *qliksense.Qliksense) *cobra.Command {
 				if err := p.SetUpQliksenseDefaultContext(); err != nil {
 					panic(err)
 				}
-				pf := preflight.NewPreflightConfig(p.QliksenseHome)
+				pf := api.NewPreflightConfig(p.QliksenseHome)
 				if err := pf.Initialize(); err != nil {
 					panic(err)
 				}

--- a/pkg/api/preflight_apis.go
+++ b/pkg/api/preflight_apis.go
@@ -1,10 +1,9 @@
-package preflight
+package api
 
 import (
 	"os"
 	"path/filepath"
 
-	api "github.com/qlik-oss/sense-installer/pkg/api"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -44,7 +43,7 @@ func NewPreflightConfig(qHome string) *PreflightConfig {
 		return p
 	}
 	p = &PreflightConfig{}
-	if err := api.ReadFromFile(p, conFile); err != nil {
+	if err := ReadFromFile(p, conFile); err != nil {
 		return nil
 	}
 	return p
@@ -61,7 +60,7 @@ func (p *PreflightConfig) Write() error {
 	if err := os.MkdirAll(pDir, os.ModePerm); err != nil {
 		return err
 	}
-	return api.WriteToFile(p, p.GetConfigFilePath())
+	return WriteToFile(p, p.GetConfigFilePath())
 }
 
 func (p *PreflightConfig) AddMinK8sV(version string) {

--- a/pkg/api/preflight_apis_test.go
+++ b/pkg/api/preflight_apis_test.go
@@ -1,10 +1,8 @@
-package preflight
+package api
 
 import (
 	"io/ioutil"
 	"testing"
-
-	api "github.com/qlik-oss/sense-installer/pkg/api"
 )
 
 func Test_Initalize(t *testing.T) {
@@ -21,7 +19,7 @@ func Test_Initalize(t *testing.T) {
 	p := &PreflightConfig{
 		QliksenseHomePath: tempDir,
 	}
-	if err := api.ReadFromFile(p, pf.GetConfigFilePath()); err != nil {
+	if err := ReadFromFile(p, pf.GetConfigFilePath()); err != nil {
 		t.Log(err)
 		t.FailNow()
 	}

--- a/pkg/preflight/preflight_utils.go
+++ b/pkg/preflight/preflight_utils.go
@@ -12,27 +12,22 @@ import (
 	"time"
 
 	"github.com/mitchellh/go-homedir"
-
-	"k8s.io/apimachinery/pkg/util/wait"
-
-	"k8s.io/client-go/util/retry"
-
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/tools/remotecommand"
-	"k8s.io/kubectl/pkg/scheme"
-
 	"github.com/pkg/errors"
 	"github.com/qlik-oss/sense-installer/pkg/api"
 	"github.com/qlik-oss/sense-installer/pkg/qliksense"
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/api/rbac/v1beta1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	restclient "k8s.io/client-go/rest"
-
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/kubectl/pkg/scheme"
 )
 
 var gracePeriod int64 = 0
@@ -41,8 +36,8 @@ type QliksensePreflight struct {
 	Q *qliksense.Qliksense
 }
 
-func (qp *QliksensePreflight) GetPreflightConfigObj() *PreflightConfig {
-	return NewPreflightConfig(qp.Q.QliksenseHome)
+func (qp *QliksensePreflight) GetPreflightConfigObj() *api.PreflightConfig {
+	return api.NewPreflightConfig(qp.Q.QliksenseHome)
 }
 
 func InitPreflight() (string, []byte, error) {

--- a/pkg/qliksense/docker.go
+++ b/pkg/qliksense/docker.go
@@ -73,12 +73,9 @@ func (q *Qliksense) PullImagesForCurrentCR() error {
 	}
 
 	images := versionOut.Images
-	if err := q.appendOperatorImages(&images); err != nil {
+	if err := q.appendAdditionalImages(&images, qcr); err != nil {
 		return err
 	}
-
-	q.appendGitOpsImage(&images, qcr)
-	q.appendPreflightImages(&images)
 
 	for _, image := range images {
 		if err := pullImage(image, imagesDir); err != nil {
@@ -189,7 +186,7 @@ func (q *Qliksense) PushImagesForCurrentCR() error {
 	}
 
 	images := versionOut.Images
-	if err := q.appendOperatorImages(&images); err != nil {
+	if err := q.appendAdditionalImages(&images, qcr); err != nil {
 		return err
 	}
 
@@ -207,6 +204,15 @@ func (q *Qliksense) PushImagesForCurrentCR() error {
 		}
 	}
 
+	return nil
+}
+
+func (q *Qliksense) appendAdditionalImages(images *[]string, qcr *qapi.QliksenseCR) error {
+	if err := q.appendOperatorImages(images); err != nil {
+		return err
+	}
+	q.appendGitOpsImage(images, qcr)
+	q.appendPreflightImages(images)
 	return nil
 }
 

--- a/pkg/qliksense/docker.go
+++ b/pkg/qliksense/docker.go
@@ -8,8 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/qlik-oss/sense-installer/pkg/preflight"
-
 	"github.com/containers/image/v5/copy"
 	"github.com/containers/image/v5/signature"
 	"github.com/containers/image/v5/transports/alltransports"
@@ -105,7 +103,7 @@ func (q *Qliksense) appendGitOpsImage(images *[]string, qcr *qapi.QliksenseCR) {
 }
 
 func (q *Qliksense) appendPreflightImages(images *[]string) {
-	pf := preflight.NewPreflightConfig(q.QliksenseHome)
+	pf := qapi.NewPreflightConfig(q.QliksenseHome)
 	for _, preflightImage := range pf.GetImageMap() {
 		*images = append(*images, preflightImage)
 	}

--- a/pkg/qliksense/docker_test.go
+++ b/pkg/qliksense/docker_test.go
@@ -232,7 +232,7 @@ spec:
 		t.Fatalf("unexpected error appending additional images: %v", err)
 	}
 
-	expectedNumberAdditionalImages := 4
+	expectedNumberAdditionalImages := 5
 	if len(images) != expectedNumberAdditionalImages {
 		t.Fatalf("unexpected number of additional images: %v, expected: %v", len(images), expectedNumberAdditionalImages)
 	}
@@ -264,6 +264,11 @@ spec:
 		return image == "subfuzion/netcat"
 	}) {
 		t.Fatal("expected to find the netcat Preflight image in the list, but it wasn't there")
+	}
+	if !haveMatchingImage(func(image string) bool {
+		return image == "mongo"
+	}) {
+		t.Fatal("expected to find the mongo Preflight image in the list, but it wasn't there")
 	}
 }
 

--- a/pkg/qliksense/docker_test.go
+++ b/pkg/qliksense/docker_test.go
@@ -129,12 +129,12 @@ func Test_Pull_Push_ImagesForCurrentCR(t *testing.T) {
 			}
 			defer os.RemoveAll(tmpQlikSenseHome)
 
-			if err := setupQlikSenseHome(t, tmpQlikSenseHome, registry, testCase.clientAuth); err != nil {
+			if err := setupQlikSenseHome(tmpQlikSenseHome, registry, testCase.clientAuth); err != nil {
 				t.Fatalf("unexpected error setting up qliksense home: %v", err)
 			}
 			q := &Qliksense{
 				QliksenseHome: tmpQlikSenseHome,
-				CrdBox:        packr.New("crds", "./crds"),
+				CrdBox:        &packr.Box{},
 			}
 			var versionOut VersionOutput
 
@@ -173,7 +173,101 @@ func Test_Pull_Push_ImagesForCurrentCR(t *testing.T) {
 	}
 }
 
-func setupQlikSenseHome(t *testing.T, tmpQlikSenseHome string, registry *testRegistryV2, clientAuth clientAuthType) error {
+func Test_appendAdditionalImages(t *testing.T) {
+	tmpQlikSenseHome, err := ioutil.TempDir("", "tmp-qlik-sense-home-")
+	if err != nil {
+		t.Fatalf("unexpected error creating tmp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpQlikSenseHome)
+
+	if err := ioutil.WriteFile(path.Join(tmpQlikSenseHome, "config.yaml"), []byte(`
+apiVersion: config.qlik.com/v1
+kind: QliksenseConfig
+metadata:
+  name: QliksenseConfigMetadata
+spec:
+  contexts:
+  - name: qlik-default
+    crFile: contexts/qlik-default/qlik-default.yaml
+  currentContext: qlik-default
+`), os.ModePerm); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	defaultContextDir := path.Join(tmpQlikSenseHome, "contexts", "qlik-default")
+	if err := os.MkdirAll(defaultContextDir, os.ModePerm); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := ioutil.WriteFile(path.Join(defaultContextDir, "qlik-default.yaml"), []byte(`
+apiVersion: qlik.com/v1
+kind: Qliksense
+metadata:
+  name: qlik-default
+spec:
+  gitOps:
+    image: some-gitops-image
+`), os.ModePerm); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	q := &Qliksense{
+		QliksenseHome: tmpQlikSenseHome,
+		CrdBox:        packr.New("crds", "./crds"),
+	}
+
+	pf := api.NewPreflightConfig(q.QliksenseHome)
+	if err := pf.Initialize(); err != nil {
+		t.Fatalf("unexpected error initializing preflight: %v", err)
+	}
+
+	qConfig := api.NewQConfig(q.QliksenseHome)
+	qcr, err := qConfig.GetCurrentCR()
+	if err != nil {
+		t.Fatalf("unexpected error getting current CR: %v", err)
+	}
+
+	images := make([]string, 0)
+	if err := q.appendAdditionalImages(&images, qcr); err != nil {
+		t.Fatalf("unexpected error appending additional images: %v", err)
+	}
+
+	expectedNumberAdditionalImages := 4
+	if len(images) != expectedNumberAdditionalImages {
+		t.Fatalf("unexpected number of additional images: %v, expected: %v", len(images), expectedNumberAdditionalImages)
+	}
+
+	haveMatchingImage := func(test func(string) bool) bool {
+		for _, image := range images {
+			if test(image) {
+				return true
+			}
+		}
+		return false
+	}
+	if !haveMatchingImage(func(image string) bool {
+		return strings.Contains(image, "qlik-docker-oss.bintray.io/qliksense-operator:v")
+	}) {
+		t.Fatal("expected to find the operator image in the list, but it wasn't there")
+	}
+	if !haveMatchingImage(func(image string) bool {
+		return image == "some-gitops-image"
+	}) {
+		t.Fatal("expected to find the GitOps image in the list, but it wasn't there")
+	}
+	if !haveMatchingImage(func(image string) bool {
+		return image == "nginx"
+	}) {
+		t.Fatal("expected to find the nginx Preflight image in the list, but it wasn't there")
+	}
+	if !haveMatchingImage(func(image string) bool {
+		return image == "subfuzion/netcat"
+	}) {
+		t.Fatal("expected to find the netcat Preflight image in the list, but it wasn't there")
+	}
+}
+
+func setupQlikSenseHome(tmpQlikSenseHome string, registry *testRegistryV2, clientAuth clientAuthType) error {
 	if err := ioutil.WriteFile(path.Join(tmpQlikSenseHome, "config.yaml"), []byte(`
 apiVersion: config.qlik.com/v1
 kind: QliksenseConfig

--- a/pkg/qliksense/docker_test.go
+++ b/pkg/qliksense/docker_test.go
@@ -68,6 +68,9 @@ const (
 )
 
 func Test_Pull_Push_ImagesForCurrentCR(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping pull/push tests in short mode")
+	}
 	var testCases = []struct {
 		name              string
 		registryAuth      bool


### PR DESCRIPTION
- Adding Preflight and GitOps images to those being pulled/pushed; 
- Moving files around to avoid circular references;
- Adding additional make target `test-short` that skips any long running tests (for now only pull/push);
 