### PR TITLE
add base64 flag and input pipe

### DIFF
--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"archive/zip"
 	"compress/gzip"
+	b64 "encoding/base64"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -61,7 +62,7 @@ func ReadKeys(keyFile string) ([]byte, error) {
 }
 
 // ProcessConfigArgs processes args and returns an service, key, value slice
-func ProcessConfigArgs(args []string) ([]*ServiceKeyValue, error) {
+func ProcessConfigArgs(args []string, base64Encoded bool) ([]*ServiceKeyValue, error) {
 	// prepare received args
 	// split args[0] into key and value
 	if len(args) == 0 {
@@ -81,10 +82,18 @@ func ProcessConfigArgs(args []string) ([]*ServiceKeyValue, error) {
 		if len(second) != 2 {
 			return nil, notValidErr
 		}
+		resultValue := strings.Trim(first[1], "\"")
+		if base64Encoded {
+			if decodeByte, err := b64.StdEncoding.DecodeString(resultValue); err != nil {
+				return nil, err
+			} else {
+				resultValue = strings.Trim(string(decodeByte), "\n ")
+			}
+		}
 		resultSvcKV[i] = &ServiceKeyValue{
 			SvcName: second[0],
 			Key:     second[1],
-			Value:   strings.ReplaceAll(first[1], `"`, ""),
+			Value:   resultValue,
 		}
 	}
 	return resultSvcKV, nil

--- a/pkg/api/utils_test.go
+++ b/pkg/api/utils_test.go
@@ -16,7 +16,7 @@ func TestProcessConfigArgs(t *testing.T) {
 	expectedKeys := []string{"mongodb", "test", "dash-key", "dot-key", "key123", "keyequal"}
 	expectedValue := []string{"mongouri://something?ffall", "value_under", "value-dash", "127.0.0.1", "value123", "newvalue=@hj"}
 	exppectedSvc := []string{"qliksense", "test_under", "test-dash", "test-dot", "test123", "test-equal"}
-	sv, err := ProcessConfigArgs(args)
+	sv, err := ProcessConfigArgs(args, false)
 	if err != nil {
 		t.Log(err)
 		t.FailNow()


### PR DESCRIPTION
new flag has been added to `set-configs` and `set-secrets` command
`qliksense config set-configs qliksense.idpConfigs=base64-encoded-value --base64`
`echo "idpconigs value" | base64 | qliksense config set-configs qliksense.idpConfigs --base64`
`echo "idpconigs value" | qliksense config set-configs qliksense.idpConfigs`

Signed-off-by: Foysal Iqbal <mqb@qlik.com>