### PR TITLE
Accounting for imageRegistry CR setting when executing preflight checks

### DIFF
--- a/cmd/qliksense/pull_push.go
+++ b/cmd/qliksense/pull_push.go
@@ -37,7 +37,7 @@ func pushQliksenseImages(q *qliksense.Qliksense) *cobra.Command {
 			qConfig := qapi.NewQConfig(q.QliksenseHome)
 			if qcr, err := qConfig.GetCurrentCR(); err != nil {
 				return err
-			} else if registry := qcr.GetImageRegistry(); registry == "" {
+			} else if registry := qcr.Spec.GetImageRegistry(); registry == "" {
 				return errors.New("no image registry in config")
 			} else {
 				return q.PushImagesForCurrentCR()

--- a/go.sum
+++ b/go.sum
@@ -860,10 +860,6 @@ github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDa
 github.com/prometheus/procfs v0.0.5 h1:3+auTFlqw+ZaQYJARz6ArODtkaIwtvBTx3N2NehQlL8=
 github.com/prometheus/procfs v0.0.5/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/qlik-oss/k-apis v0.0.35 h1:LdxfN43UE4Fy4LAmFcsv2nXCuxfxowKY66rpUQHAyDU=
-github.com/qlik-oss/k-apis v0.0.35/go.mod h1:DNiWYqCqPIN216l7+1rccArNIYPb1Le7kYDcPSyNp+Q=
-github.com/qlik-oss/k-apis v0.0.36 h1:Ztd31rKn4uR3AQRb9QxYf1KEll4+Ku1E8DzCpplBw/g=
-github.com/qlik-oss/k-apis v0.0.36/go.mod h1:yoYGgPJ/H0t9H3NSq64dWfyQY6QWi2L9c+hCJoVO03U=
 github.com/qlik-oss/k-apis v0.0.39 h1:fIGCC7f9kU7319VTSJKr3fLoA9E4MjusRFmOjX3ypis=
 github.com/qlik-oss/k-apis v0.0.39/go.mod h1:yoYGgPJ/H0t9H3NSq64dWfyQY6QWi2L9c+hCJoVO03U=
 github.com/qlik-oss/kustomize/api v0.3.3-0.20200402170547-2e8140160c36 h1:BuT+cnXPQ6mcOWTDS1S8GXy65LAEMdPuNQCC36rMq28=

--- a/pkg/api/apis.go
+++ b/pkg/api/apis.go
@@ -458,17 +458,6 @@ func (cr *QliksenseCR) GetString() (string, error) {
 	return string(out), nil
 }
 
-func (cr *QliksenseCR) GetImageRegistry() string {
-	for _, nameValues := range cr.Spec.Configs {
-		for _, nameValue := range nameValues {
-			if nameValue.Name == "imageRegistry" {
-				return nameValue.Value
-			}
-		}
-	}
-	return ""
-}
-
 func (cr *QliksenseCR) GetK8sSecretsFolder(qlikSenseHomeDir string) string {
 	return filepath.Join(qlikSenseHomeDir, qliksenseContextsDirName, cr.GetName(), qliksenseSecretsDirName)
 }

--- a/pkg/api/preflight_apis_test.go
+++ b/pkg/api/preflight_apis_test.go
@@ -1,39 +1,138 @@
 package api
 
 import (
+	"fmt"
 	"io/ioutil"
+	"os"
+	"path"
 	"testing"
 )
 
 func Test_Initalize(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Log(err)
-		t.FailNow()
+	testCases := []struct {
+		name     string
+		validate func(t *testing.T, tempDir string)
+	}{
+		{
+			name: "without account for imageRegistry",
+			validate: func(t *testing.T, tempDir string) {
+				preflightConfig := NewPreflightConfig(tempDir)
+				imageName, err := preflightConfig.GetImageName("test", false)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if imageName != "testimage" {
+					t.Fatalf("expected image name: testimage, got: %v", imageName)
+				}
+			},
+		},
+		{
+			name: "with account for configured imageRegistry",
+			validate: func(t *testing.T, tempDir string) {
+				registry := "registryFoo"
+				setupQliksenseTestDefaultContext(t, tempDir, fmt.Sprintf(`
+apiVersion: qlik.com/v1
+kind: Qliksense
+metadata:
+  name: qlik-default
+spec:
+  configs:
+    qliksense:
+    - name: imageRegistry
+      value: %v
+`, registry))
+				preflightConfig := NewPreflightConfig(tempDir)
+				imageName, err := preflightConfig.GetImageName("test", true)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				expectedImageName := fmt.Sprintf("%v/testimage", registry)
+				if imageName != expectedImageName {
+					t.Fatalf("expected image name: %v, got: %v", expectedImageName, imageName)
+				}
+			},
+		},
+		{
+			name: "with account for un-configured imageRegistry",
+			validate: func(t *testing.T, tempDir string) {
+				setupQliksenseTestDefaultContext(t, tempDir, `
+apiVersion: qlik.com/v1
+kind: Qliksense
+metadata:
+  name: qlik-default
+spec:
+  configs:
+    qliksense:
+    - name: something
+      value: other
+`)
+				preflightConfig := NewPreflightConfig(tempDir)
+				imageName, err := preflightConfig.GetImageName("test", true)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				expectedImageName := "testimage"
+				if imageName != expectedImageName {
+					t.Fatalf("expected image name: %v, got: %v", expectedImageName, imageName)
+				}
+			},
+		},
 	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			tempDir, err := ioutil.TempDir("", "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(tempDir)
+			setupPreflightConfig(t, tempDir)
+			testCase.validate(t, tempDir)
+		})
+	}
+}
+
+func setupPreflightConfig(t *testing.T, tempDir string) {
 	pf := NewPreflightConfig(tempDir)
 	if err := pf.Initialize(); err != nil {
-		t.Log()
-		t.FailNow()
+		t.Fatal(err)
 	}
 	p := &PreflightConfig{
 		QliksenseHomePath: tempDir,
 	}
 	if err := ReadFromFile(p, pf.GetConfigFilePath()); err != nil {
-		t.Log(err)
-		t.FailNow()
+		t.Fatal(err)
 	}
 	if p.GetMinK8sVersion() != "1.15" {
-		t.Log("expected k8 version: 1.15, but got " + p.GetMinK8sVersion())
-		t.Fail()
+		t.Fatalf("expected k8 version: 1.15, but got " + p.GetMinK8sVersion())
 	}
 	p.AddImage("test", "testimage")
 	if err := p.Write(); err != nil {
-		t.Log(err)
-		t.Fail()
+		t.Fatal(err)
 	}
-	p2 := NewPreflightConfig(tempDir)
-	if p2.GetImageName("test") != "testimage" {
-		t.Log("expected image name: testimage, got: " + p2.GetImageName("test"))
+}
+
+func setupQliksenseTestDefaultContext(t *testing.T, tmpQlikSenseHome, CR string) {
+	if err := ioutil.WriteFile(path.Join(tmpQlikSenseHome, "config.yaml"), []byte(`
+apiVersion: config.qlik.com/v1
+kind: QliksenseConfig
+metadata:
+  name: QliksenseConfigMetadata
+spec:
+  contexts:
+  - name: qlik-default
+    crFile: contexts/qlik-default/qlik-default.yaml
+  currentContext: qlik-default
+`), os.ModePerm); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	defaultContextDir := path.Join(tmpQlikSenseHome, "contexts", "qlik-default")
+	if err := os.MkdirAll(defaultContextDir, os.ModePerm); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := ioutil.WriteFile(path.Join(defaultContextDir, "qlik-default.yaml"), []byte(CR), os.ModePerm); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/pkg/preflight/deployability.go
+++ b/pkg/preflight/deployability.go
@@ -67,7 +67,12 @@ func (qp *QliksensePreflight) checkPfPod(clientset *kubernetes.Clientset, namesp
 	// create a pod
 	podName := "pod-pf-check"
 	commandToRun := []string{}
-	pod, err := createPreflightTestPod(clientset, namespace, podName, qp.GetPreflightConfigObj().GetImageName(nginx), commandToRun)
+
+	imageName, err := qp.GetPreflightConfigObj().GetImageName(nginx, true)
+	if err != nil {
+		return err
+	}
+	pod, err := createPreflightTestPod(clientset, namespace, podName, imageName, commandToRun)
 	if err != nil {
 		err = fmt.Errorf("error: unable to create pod %s - %v\n", podName, err)
 		return err
@@ -104,7 +109,11 @@ func checkPfService(clientset *kubernetes.Clientset, namespace string) error {
 
 func (qp *QliksensePreflight) checkPfDeployment(clientset *kubernetes.Clientset, namespace, depName string) error {
 	// check if we are able to create a deployment
-	pfDeployment, err := createPreflightTestDeployment(clientset, namespace, depName, qp.GetPreflightConfigObj().GetImageName(nginx))
+	imageName, err := qp.GetPreflightConfigObj().GetImageName(nginx, true)
+	if err != nil {
+		return err
+	}
+	pfDeployment, err := createPreflightTestDeployment(clientset, namespace, depName, imageName)
 	if err != nil {
 		err = fmt.Errorf("error: unable to create deployment: %v\n", err)
 		return err

--- a/pkg/preflight/dns_check.go
+++ b/pkg/preflight/dns_check.go
@@ -20,7 +20,11 @@ func (qp *QliksensePreflight) CheckDns(namespace string, kubeConfigContents []by
 
 	// creating deployment
 	depName := "dep-dns-preflight-check"
-	dnsDeployment, err := createPreflightTestDeployment(clientset, namespace, depName, qp.GetPreflightConfigObj().GetImageName(nginx))
+	nginxImageName, err := qp.GetPreflightConfigObj().GetImageName(nginx, true)
+	if err != nil {
+		return err
+	}
+	dnsDeployment, err := createPreflightTestDeployment(clientset, namespace, depName, nginxImageName)
 	if err != nil {
 		err = fmt.Errorf("error: unable to create deployment: %v\n", err)
 		fmt.Println(err)
@@ -44,7 +48,11 @@ func (qp *QliksensePreflight) CheckDns(namespace string, kubeConfigContents []by
 	// create a pod
 	podName := "pf-pod-1"
 	commandToRun := []string{"sh", "-c", "sleep 10; nc -z -v -w 1 " + dnsService.Name + " 80"}
-	dnsPod, err := createPreflightTestPod(clientset, namespace, podName, qp.GetPreflightConfigObj().GetImageName(netcat), commandToRun)
+	netcatImageName, err := qp.GetPreflightConfigObj().GetImageName(netcat, true)
+	if err != nil {
+		return err
+	}
+	dnsPod, err := createPreflightTestPod(clientset, namespace, podName, netcatImageName, commandToRun)
 	if err != nil {
 		err = fmt.Errorf("error: unable to create pod : %s\n", podName)
 		return err

--- a/pkg/preflight/mongo_check.go
+++ b/pkg/preflight/mongo_check.go
@@ -49,7 +49,11 @@ func (qp *QliksensePreflight) mongoConnCheck(kubeConfigContents []byte, namespac
 	// create a pod
 	podName := "pf-mongo-pod"
 	commandToRun := []string{"sh", "-c", "sleep 10;mongo " + mongodbUrl}
-	mongoPod, err := createPreflightTestPod(clientset, namespace, podName, qp.GetPreflightConfigObj().GetImageName(mongo), commandToRun)
+	imageName, err := qp.GetPreflightConfigObj().GetImageName(mongo, true)
+	if err != nil {
+		return err
+	}
+	mongoPod, err := createPreflightTestPod(clientset, namespace, podName, imageName, commandToRun)
 	if err != nil {
 		err = fmt.Errorf("error: unable to create pod : %v\n", err)
 		return err

--- a/pkg/qliksense/docker.go
+++ b/pkg/qliksense/docker.go
@@ -170,7 +170,7 @@ func (q *Qliksense) PushImagesForCurrentCR() error {
 	if err != nil {
 		if os.IsNotExist(err) {
 			dockerConfigJsonSecret = &qapi.DockerConfigJsonSecret{
-				Uri: qcr.GetImageRegistry(),
+				Uri: qcr.Spec.GetImageRegistry(),
 			}
 		} else {
 			return err

--- a/pkg/qliksense/install.go
+++ b/pkg/qliksense/install.go
@@ -3,6 +3,7 @@ package qliksense
 import (
 	"errors"
 	"fmt"
+	"path"
 	"path/filepath"
 
 	"github.com/qlik-oss/k-apis/pkg/config"
@@ -116,10 +117,10 @@ func (q *Qliksense) InstallQK8s(version string, opts *InstallCommandOptions, kee
 
 func (q *Qliksense) getProcessedOperatorControllerString(qcr *qapi.QliksenseCR) (string, error) {
 	operatorControllerString := q.GetOperatorControllerString()
-	if imageRegistry := qcr.GetImageRegistry(); imageRegistry != "" {
+	if imageRegistry := qcr.Spec.GetImageRegistry(); imageRegistry != "" {
 		return kustomizeForImageRegistry(operatorControllerString, pullSecretName,
-			fmt.Sprintf("%v/%v", qliksenseOperatorImageRepo, qliksenseOperatorImageName),
-			fmt.Sprintf("%v/%v", imageRegistry, qliksenseOperatorImageName))
+			path.Join(qliksenseOperatorImageRepo, qliksenseOperatorImageName),
+			path.Join(imageRegistry, qliksenseOperatorImageName))
 	}
 	return operatorControllerString, nil
 }


### PR DESCRIPTION
If the `imageRegistry` is set in the CR, then the `preflight` checks will be executed based on the assumption that the docker images it uses have been pushed to the provided registry.  