### PR TITLE
install and apply commands can pull/push images

### DIFF
--- a/cmd/qliksense/about.go
+++ b/cmd/qliksense/about.go
@@ -39,7 +39,7 @@ qliksense about --profile=test
     then get version information based on the default profile in the qliksense-k8s repo master
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if gitRef, err := getAboutCommandGitRef(args); err != nil {
+			if gitRef, err := getSingleArg(args); err != nil {
 				return err
 			} else if vout, err := q.About(gitRef, opts.Profile); err != nil {
 				return err
@@ -56,7 +56,7 @@ qliksense about --profile=test
 	return c
 }
 
-func getAboutCommandGitRef(args []string) (string, error) {
+func getSingleArg(args []string) (string, error) {
 	if len(args) > 1 {
 		return "", errors.New("too many arguments, only 1 expected")
 	} else if len(args) == 1 {

--- a/cmd/qliksense/apply.go
+++ b/cmd/qliksense/apply.go
@@ -31,7 +31,7 @@ func applyCmd(q *qliksense.Qliksense) *cobra.Command {
 	f.StringVarP(&opts.RotateKeys, "rotateKeys", "r", "", "Rotate JWT keys for qliksense (yes:rotate keys/ no:use exising keys from cluster/ None: use default EJSON_KEY from env")
 	f.BoolVar(&keepPatchFiles, keepPatchFilesFlagName, keepPatchFiles, keepPatchFilesFlagUsage)
 
-	eulaPreRunHooks.addValidator(c.Name(), loadOrApplyCommandEulaPreRunHook)
+	eulaPreRunHooks.addValidator(c.CommandPath(), loadOrApplyCommandEulaPreRunHook)
 
 	return c
 }

--- a/cmd/qliksense/apply.go
+++ b/cmd/qliksense/apply.go
@@ -1,7 +1,12 @@
 package main
 
 import (
+	"errors"
+	"fmt"
 	"io"
+	"io/ioutil"
+
+	qapi "github.com/qlik-oss/sense-installer/pkg/api"
 
 	"github.com/qlik-oss/sense-installer/pkg/qliksense"
 	"github.com/spf13/cobra"
@@ -10,7 +15,7 @@ import (
 func applyCmd(q *qliksense.Qliksense) *cobra.Command {
 	opts := &qliksense.InstallCommandOptions{}
 	filePath := ""
-	keepPatchFiles := false
+	keepPatchFiles, pull, push := false, false, false
 	c := &cobra.Command{
 		Use:     "apply",
 		Short:   "install qliksense based on provided cr file",
@@ -18,7 +23,10 @@ func applyCmd(q *qliksense.Qliksense) *cobra.Command {
 		Example: `qliksense apply -f file_name or cat cr_file | qliksense apply -f -`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runLoadOrApplyCommandE(cmd, func(reader io.Reader) error {
-				return q.ApplyCRFromReader(reader, opts, keepPatchFiles, true)
+				if err := validatePullPushFlagsOnApply(reader, pull, push); err != nil {
+					return err
+				}
+				return q.ApplyCRFromReader(reader, opts, keepPatchFiles, true, pull, push)
 			})
 		},
 	}
@@ -30,8 +38,26 @@ func applyCmd(q *qliksense.Qliksense) *cobra.Command {
 	f.StringVarP(&opts.MongoDbUri, "mongoDbUri", "m", "", "mongoDbUri for qliksense (i.e. mongodb://qlik-default-mongodb:27017/qliksense?ssl=false)")
 	f.StringVarP(&opts.RotateKeys, "rotateKeys", "r", "", "Rotate JWT keys for qliksense (yes:rotate keys/ no:use exising keys from cluster/ None: use default EJSON_KEY from env")
 	f.BoolVar(&keepPatchFiles, keepPatchFilesFlagName, keepPatchFiles, keepPatchFilesFlagUsage)
+	f.BoolVarP(&pull, pullFlagName, pullFlagShorthand, pull, pullFlagUsage)
+	f.BoolVarP(&push, pushFlagName, pushFlagShorthand, push, pushFlagUsage)
 
 	eulaPreRunHooks.addValidator(c.CommandPath(), loadOrApplyCommandEulaPreRunHook)
 
 	return c
+}
+
+func validatePullPushFlagsOnApply(reader io.Reader, pull, push bool) error {
+	if pull && !push {
+		fmt.Printf("WARNING: pulling images without pushing them")
+	}
+	if push {
+		if crBytes, err := ioutil.ReadAll(reader); err != nil {
+			return err
+		} else if cr, err := qapi.CreateCRObjectFromString(string(crBytes)); err != nil {
+			return err
+		} else if registry := cr.Spec.GetImageRegistry(); registry == "" {
+			return errors.New("no image registry set in the CR; to set it use: qliksense config set-image-registry")
+		}
+	}
+	return nil
 }

--- a/cmd/qliksense/eula.go
+++ b/cmd/qliksense/eula.go
@@ -48,7 +48,8 @@ var eulaPreRunHooks = eulaPreRunHooksT{
 }
 
 func commandAlwaysRequiresEulaAcceptance(commandName string) bool {
-	return commandName == "install" || commandName == "upgrade" || commandName == "apply"
+	return commandName == fmt.Sprintf("%v install", rootCommandName) ||
+		commandName == fmt.Sprintf("%v apply", rootCommandName)
 }
 
 func globalEulaPreRun(cmd *cobra.Command, q *qliksense.Qliksense) {

--- a/cmd/qliksense/eula.go
+++ b/cmd/qliksense/eula.go
@@ -52,9 +52,9 @@ func commandAlwaysRequiresEulaAcceptance(commandName string) bool {
 }
 
 func globalEulaPreRun(cmd *cobra.Command, q *qliksense.Qliksense) {
-	if isEulaEnforced(cmd.Name()) {
+	if isEulaEnforced(cmd.CommandPath()) {
 		if strings.TrimSpace(strings.ToLower(cmd.Flag("acceptEULA").Value.String())) != "yes" {
-			if eulaPreRunHook := eulaPreRunHooks.getValidator(cmd.Name()); eulaPreRunHook != nil {
+			if eulaPreRunHook := eulaPreRunHooks.getValidator(cmd.CommandPath()); eulaPreRunHook != nil {
 				if eulaAccepted, err := eulaPreRunHook(cmd, q); err != nil {
 					panic(err)
 				} else if !eulaAccepted {
@@ -70,7 +70,7 @@ func globalEulaPreRun(cmd *cobra.Command, q *qliksense.Qliksense) {
 }
 
 func globalEulaPostRun(cmd *cobra.Command, q *qliksense.Qliksense) {
-	if isEulaEnforced(cmd.Name()) {
+	if isEulaEnforced(cmd.CommandPath()) {
 		if err := q.SetEulaAccepted(); err != nil {
 			panic(err)
 		}

--- a/cmd/qliksense/load.go
+++ b/cmd/qliksense/load.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"bytes"
-	"io"
+	"fmt"
 	"io/ioutil"
 	"os"
 
@@ -20,8 +20,8 @@ func loadCrFile(q *qliksense.Qliksense) *cobra.Command {
 		Long:    `load a CR a file and create necessary structure for future use`,
 		Example: `qliksense load -f file_name or cat cr_file | qliksense load -f -`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runLoadOrApplyCommandE(cmd, func(reader io.Reader) error {
-				return q.LoadCr(reader, overwriteExistingContext)
+			return runLoadOrApplyCommandE(cmd, func(buffer []byte) error {
+				return q.LoadCr(bytes.NewReader(buffer), overwriteExistingContext)
 			})
 		},
 	}
@@ -30,7 +30,7 @@ func loadCrFile(q *qliksense.Qliksense) *cobra.Command {
 	c.MarkFlagRequired("file")
 	f.BoolVarP(&overwriteExistingContext, "overwrite", "o", overwriteExistingContext, "Overwrite any existing contexts with the same name")
 
-	eulaPreRunHooks.addValidator(c.CommandPath(), loadOrApplyCommandEulaPreRunHook)
+	eulaPreRunHooks.addValidator(fmt.Sprintf("%v %v", rootCommandName, c.Name()), loadOrApplyCommandEulaPreRunHook)
 	return c
 }
 
@@ -70,15 +70,19 @@ func loadOrApplyCommandEulaPreRunHook(cmd *cobra.Command, q *qliksense.Qliksense
 	}
 }
 
-func runLoadOrApplyCommandE(cmd *cobra.Command, callBack func(io.Reader) error) error {
+func runLoadOrApplyCommandE(cmd *cobra.Command, callBack func(buffer []byte) error) error {
 	if crBytes := eulaPreRunHooks.getPostValidationArtifact("CR"); crBytes != nil {
-		return callBack(bytes.NewBuffer(crBytes.([]byte)))
+		return callBack(crBytes.([]byte))
 	} else {
 		file, err := getCrFileFromFlag(cmd, "file")
 		if err != nil {
 			return err
 		}
 		defer file.Close()
-		return callBack(file)
+		if crBytes, err := ioutil.ReadAll(file); err != nil {
+			return err
+		} else {
+			return callBack(crBytes)
+		}
 	}
 }

--- a/cmd/qliksense/load.go
+++ b/cmd/qliksense/load.go
@@ -30,7 +30,7 @@ func loadCrFile(q *qliksense.Qliksense) *cobra.Command {
 	c.MarkFlagRequired("file")
 	f.BoolVarP(&overwriteExistingContext, "overwrite", "o", overwriteExistingContext, "Overwrite any existing contexts with the same name")
 
-	eulaPreRunHooks.addValidator(c.Name(), loadOrApplyCommandEulaPreRunHook)
+	eulaPreRunHooks.addValidator(c.CommandPath(), loadOrApplyCommandEulaPreRunHook)
 	return c
 }
 

--- a/pkg/qliksense/apply.go
+++ b/pkg/qliksense/apply.go
@@ -1,12 +1,13 @@
 package qliksense
 
 import (
+	"fmt"
 	"io"
 
 	qapi "github.com/qlik-oss/sense-installer/pkg/api"
 )
 
-func (q *Qliksense) ApplyCRFromReader(r io.Reader, opts *InstallCommandOptions, keepPatchFiles, overwriteExistingContext bool) error {
+func (q *Qliksense) ApplyCRFromReader(r io.Reader, opts *InstallCommandOptions, keepPatchFiles, overwriteExistingContext, pull, push bool) error {
 	if err := q.LoadCr(r, overwriteExistingContext); err != nil {
 		return err
 	}
@@ -15,19 +16,33 @@ func (q *Qliksense) ApplyCRFromReader(r io.Reader, opts *InstallCommandOptions, 
 	if err != nil {
 		return err
 	}
+	version := cr.GetLabelFromCr("version")
+
+	if pull {
+		fmt.Println("Pulling images...")
+		if err := q.PullImages(version, ""); err != nil {
+			return err
+		}
+	}
+	if push {
+		fmt.Println("Pushing images...")
+		if err := q.PushImagesForCurrentCR(); err != nil {
+			return err
+		}
+	}
+
 	if IsQliksenseInstalled(cr.GetName()) {
 		// it is needed in case want to upgrade from one version to another
 		if cr.Spec.ManifestsRoot == "" && cr.Spec.Git == nil {
-			v := cr.GetLabelFromCr("version")
-			if !qConfig.IsRepoExistForCurrent(v) {
-				if err := q.FetchQK8s(v); err != nil {
+			if !qConfig.IsRepoExistForCurrent(version) {
+				if err := q.FetchQK8s(version); err != nil {
 					return err
 				}
 			}
 		}
 		return q.UpgradeQK8s(keepPatchFiles)
 	}
-	return q.InstallQK8s(cr.GetLabelFromCr("version"), opts, keepPatchFiles)
+	return q.InstallQK8s(version, opts, keepPatchFiles)
 }
 
 func IsQliksenseInstalled(crName string) bool {

--- a/pkg/qliksense/docker.go
+++ b/pkg/qliksense/docker.go
@@ -46,8 +46,8 @@ func (q *Qliksense) PullImages(version, profile string) error {
 	}
 	if profile != "" {
 		qcr.Spec.Profile = profile
-		if e := qConfig.WriteCR(qcr); e != nil {
-			return e
+		if err := qConfig.WriteCR(qcr); err != nil {
+			return err
 		}
 	}
 	return q.PullImagesForCurrentCR()
@@ -155,7 +155,6 @@ func pullImage(image, imagesDir string) error {
 	return nil
 }
 
-// TagAndPushImages ...
 func (q *Qliksense) PushImagesForCurrentCR() error {
 	qConfig := qapi.NewQConfig(q.QliksenseHome)
 	qcr, err := qConfig.GetCurrentCR()

--- a/pkg/qliksense/kuz_test.go
+++ b/pkg/qliksense/kuz_test.go
@@ -68,7 +68,7 @@ func Test_executeKustomizeBuild_onQlikConfig_regenerateKeys(t *testing.T) {
 	configPath := path.Join(tmpDir, "config")
 	if repo, err := kapis_git.CloneRepository(configPath, defaultConfigRepoGitUrl, nil); err != nil {
 		t.Fatalf("unexpected error: %v\n", err)
-	} else if err := kapis_git.Checkout(repo, "v1.21.23-edge", "", nil); err != nil {
+	} else if err := kapis_git.Checkout(repo, "e38df644e759abf0b5941c1511d1a2cd5e3c42fa", "", nil); err != nil {
 		t.Fatalf("unexpected error: %v\n", err)
 	}
 


### PR DESCRIPTION
If a registry has been configured in the CR like so:
```
bin/qliksense config set-image-registry foo.registry.com:5000 --username testuser --password testpassword
```
Then you can `install` the CR with one command like so:
```
bin/qliksense install --pull --push
```
Or you can `apply` the CR with one command like so:
```
bin/qliksense apply -f /path/to/same-context-cr.yaml --pull --push
```