### PR TITLE
Install latest

### DIFF
--- a/pkg/qliksense/fetch.go
+++ b/pkg/qliksense/fetch.go
@@ -80,9 +80,14 @@ func fetchAndUpdateCR(qConfig *qapi.QliksenseConfig, version string) error {
 	}
 	if version == "" {
 		if qcr.GetLabelFromCr("version") == "" {
-			return errors.New("Cannot find gitref/tag/branch/version to fetch")
+			if encKey, err := qConfig.GetEncryptionKeyFor(qcr.GetName()); err != nil {
+				return err
+			} else if version, err = getLatestTag(qcr.GetFetchUrl(), qcr.GetFetchAccessToken(encKey)); err != nil {
+				return err
+			}
+		} else {
+			version = qcr.GetLabelFromCr("version")
 		}
-		version = qcr.GetLabelFromCr("version")
 	}
 	encKey, err := qConfig.GetEncryptionKeyFor(qcr.GetName())
 	if err != nil {

--- a/pkg/qliksense/fetch_test.go
+++ b/pkg/qliksense/fetch_test.go
@@ -32,4 +32,19 @@ func TestFetchAndUpdateCR(t *testing.T) {
 		t.Log("actual path: " + cr.Spec.ManifestsRoot + ", expected path: contexts/test1/qlik-k8s/v0.0.2")
 		t.FailNow()
 	}
+	//testing latest tag is fetched
+	cr.AddLabelToCr("version", "")
+	qConfig.WriteCR(cr)
+	err := fetchAndUpdateCR(qConfig, "")
+	if err != nil {
+		t.Log(err)
+		t.Fail()
+	}
+	cr = &qapi.QliksenseCR{}
+	qapi.ReadFromFile(cr, actualCrFile)
+	v := cr.GetLabelFromCr("version")
+	if v == "" || v == "v0.0.2" {
+		t.Log("should get latest but got version: " + v)
+		t.Fail()
+	}
 }

--- a/pkg/qliksense/get_installable_versions.go
+++ b/pkg/qliksense/get_installable_versions.go
@@ -151,5 +151,5 @@ func getLatestTag(repoUrl, accessToken string) (string, error) {
 			maxSem = v
 		}
 	}
-	return maxSem.String(), nil
+	return maxSem.Original(), nil
 }

--- a/pkg/qliksense/get_installable_versions_test.go
+++ b/pkg/qliksense/get_installable_versions_test.go
@@ -1,0 +1,13 @@
+package qliksense
+
+import (
+	"testing"
+)
+
+func TestGetLatestTag(t *testing.T) {
+	s, err := getLatestTag(defaultConfigRepoGitUrl, "")
+	if s == "" || err != nil {
+		t.Log(err)
+		t.Fail()
+	}
+}

--- a/pkg/qliksense/get_installable_versions_test.go
+++ b/pkg/qliksense/get_installable_versions_test.go
@@ -2,12 +2,24 @@ package qliksense
 
 import (
 	"testing"
+
+	"github.com/Masterminds/semver/v3"
 )
 
 func TestGetLatestTag(t *testing.T) {
 	s, err := getLatestTag(defaultConfigRepoGitUrl, "")
 	if s == "" || err != nil {
 		t.Log(err)
+		t.Fail()
+	}
+	sv, err := semver.NewVersion(s)
+	if err != nil {
+		t.Log(err)
+		t.Log(sv)
+	}
+	baseV, _ := semver.NewVersion("v0.0.7")
+	if !sv.GreaterThan(baseV) {
+		t.Log("Expected greater than v0.0.7, but got:  " + s)
 		t.Fail()
 	}
 }

--- a/pkg/qliksense/kuz_test.go
+++ b/pkg/qliksense/kuz_test.go
@@ -68,7 +68,7 @@ func Test_executeKustomizeBuild_onQlikConfig_regenerateKeys(t *testing.T) {
 	configPath := path.Join(tmpDir, "config")
 	if repo, err := kapis_git.CloneRepository(configPath, defaultConfigRepoGitUrl, nil); err != nil {
 		t.Fatalf("unexpected error: %v\n", err)
-	} else if err := kapis_git.Checkout(repo, "v1.21.23-edge", "", nil); err != nil {
+	} else if err := kapis_git.Checkout(repo, "v0.0.8", "", nil); err != nil {
 		t.Fatalf("unexpected error: %v\n", err)
 	}
 


### PR DESCRIPTION
`qliksense install --acceptEULA=yes`
will pull the latest tag from the repo, if there is no version already exist in
```
metadata:
  labels:
```

This is how the repo is determined
- https://github.com/qlik-oss/qliksense-k8s
- or whatever in the 
```
spec:
  fetchSource:
    repository: custermer-git-fork
```