### PR TITLE
Preflight mongo mutual tls

### DIFF
--- a/cmd/qliksense/root.go
+++ b/cmd/qliksense/root.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	. "github.com/logrusorgru/aurora"
 	ansi "github.com/mattn/go-colorable"
 	"github.com/mitchellh/go-homedir"
 	"github.com/qlik-oss/sense-installer/pkg"
@@ -15,7 +16,6 @@ import (
 	"github.com/qlik-oss/sense-installer/pkg/qliksense"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	. "github.com/logrusorgru/aurora"
 )
 
 // To run this project in debug mode, run:
@@ -195,7 +195,6 @@ func rootCmd(p *qliksense.Qliksense) *cobra.Command {
 
 	// add clean-config-repo-patches command as a sub-command to the app config sub-command
 	configCmd.AddCommand(cleanConfigRepoPatchesCmd(p))
-	
 
 	// open editor for config
 	configCmd.AddCommand(configEditCmd(p))

--- a/cmd/qliksense/root.go
+++ b/cmd/qliksense/root.go
@@ -46,7 +46,7 @@ func initAndExecute() error {
 		log.Fatal(err)
 	}
 	// create dirs and appropriate files for setting up contexts
-	api.LogDebugMessage("QliksenseHomeDir: %s", qlikSenseHome)
+	api.LogDebugMessage("QliksenseHomeDir: %s\n", qlikSenseHome)
 
 	qliksenseClient := qliksense.New(qlikSenseHome)
 	cmd := rootCmd(qliksenseClient)

--- a/pkg/api/context_apis.go
+++ b/pkg/api/context_apis.go
@@ -96,7 +96,7 @@ func WriteToFile(content interface{}, targetFile string) error {
 		log.Println(err)
 		return err
 	}
-	LogDebugMessage("Wrote content into %s", targetFile)
+	LogDebugMessage("Wrote content into %s\n", targetFile)
 	return nil
 }
 

--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -23,7 +23,7 @@ func checkExists(filename string) os.FileInfo {
 	if os.IsNotExist(err) {
 		return nil
 	}
-	LogDebugMessage("File exists")
+	LogDebugMessage("File exists\n")
 	return info
 }
 
@@ -73,7 +73,7 @@ func ProcessConfigArgs(args []string, base64Encoded bool) ([]*ServiceKeyValue, e
 	resultSvcKV := make([]*ServiceKeyValue, len(args))
 	// qliksense.mongodb=somethig
 	for i, arg := range args {
-		LogDebugMessage("Arg received: %s", arg)
+		LogDebugMessage("Arg received: %s\n", arg)
 		first := strings.SplitN(arg, "=", 2)
 		if len(first) != 2 {
 			return nil, notValidErr

--- a/pkg/preflight/mongo_check.go
+++ b/pkg/preflight/mongo_check.go
@@ -67,11 +67,12 @@ func (qp *QliksensePreflight) CheckMongo(kubeConfigContents []byte, namespace st
 	}
 	if !cleanup {
 		qp.P.LogVerboseMessage("MongodbUrl: %s\n", preflightOpts.MongoOptions.MongodbUrl)
-	}
-	// if mongoDbUrl is empty, abort check
-	if preflightOpts.MongoOptions.MongodbUrl == "" {
-		qp.P.LogVerboseMessage("Mongodb Url is empty, hence aborting preflight check\n")
-		return errors.New("MongoDbUrl is empty")
+
+		// if mongoDbUrl is empty, abort check
+		if preflightOpts.MongoOptions.MongodbUrl == "" {
+			qp.P.LogVerboseMessage("Mongodb Url is empty, hence aborting preflight check\n")
+			return errors.New("MongoDbUrl is empty")
+		}
 	}
 	if err := qp.mongoConnCheck(kubeConfigContents, namespace, preflightOpts, cleanup); err != nil {
 		return err

--- a/pkg/preflight/mongo_check.go
+++ b/pkg/preflight/mongo_check.go
@@ -3,6 +3,8 @@ package preflight
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
@@ -40,10 +42,26 @@ func (qp *QliksensePreflight) CheckMongo(kubeConfigContents []byte, namespace st
 			qp.P.LogVerboseMessage("An error occurred while retrieving mongodbUrl from current CR: %v\n", err)
 			return err
 		}
-		preflightOpts.MongoOptions.MongodbUrl = decryptedCR.Spec.GetFromSecrets("qliksense", "mongoDbUri")
+		preflightOpts.MongoOptions.MongodbUrl = strings.TrimSpace(decryptedCR.Spec.GetFromSecrets("qliksense", "mongoDbUri"))
+		tmpDir := os.TempDir()
+		caCrtFile := filepath.Join(tmpDir, "rootCA.crt")
+		clientCrtFile := filepath.Join(tmpDir, "mongoClient.crt")
+		if err := ioutil.WriteFile(caCrtFile, []byte(decryptedCR.Spec.GetFromSecrets("qliksense", "caCertificates")), 0644); err != nil {
+			return fmt.Errorf("unable to write CA crt to file: %v", err)
+		}
+		if err := ioutil.WriteFile(clientCrtFile, []byte(decryptedCR.Spec.GetFromSecrets("qliksense", "mongoDbClientCrt")), 0644); err != nil {
+			return fmt.Errorf("unable to write mongo client crt to file: %v", err)
+		}
+		preflightOpts.MongoOptions.CaCertFile = caCrtFile
+		preflightOpts.MongoOptions.ClientCertFile = clientCrtFile
 	}
 	if !cleanup {
 		qp.P.LogVerboseMessage("MongodbUrl: %s\n", preflightOpts.MongoOptions.MongodbUrl)
+	}
+	// if mongoDbUrl is empty, abort check
+	if preflightOpts.MongoOptions.MongodbUrl == "" {
+		qp.P.LogVerboseMessage("Mongodb Url is empty, hence aborting preflight check\n")
+		return errors.New("MongoDbUrl is empty")
 	}
 	if err := qp.mongoConnCheck(kubeConfigContents, namespace, preflightOpts, cleanup); err != nil {
 		return err
@@ -168,7 +186,6 @@ func (qp *QliksensePreflight) checkMongoVersion(logStr string) (bool, error) {
 	mongoVersionStrToCheck := "MongoDB server version:"
 	if strings.Contains(logStr, mongoVersionStrToCheck) {
 		logLines := strings.Split(logStr, "\n")
-
 		for _, eachline := range logLines {
 			if strings.Contains(eachline, mongoVersionStrToCheck) {
 				mongoVersionLog := strings.Split(eachline, ":")
@@ -208,7 +225,7 @@ func (qp *QliksensePreflight) createSecret(clientset *kubernetes.Clientset, name
 
 	certSecret, err := qp.createPreflightTestSecret(clientset, namespace, certSecretName, certBytes)
 	if err != nil {
-		err = fmt.Errorf("unable to create secret with ca cert : %v\n", err)
+		err = fmt.Errorf("unable to create secret with cert : %v\n", err)
 		return nil, err
 	}
 	return certSecret, nil

--- a/pkg/qliksense/context_configs.go
+++ b/pkg/qliksense/context_configs.go
@@ -18,12 +18,12 @@ import (
 
 	b64 "encoding/base64"
 
+	. "github.com/logrusorgru/aurora"
 	ansi "github.com/mattn/go-colorable"
 	"github.com/qlik-oss/sense-installer/pkg/api"
 	_ "gopkg.in/yaml.v2"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	. "github.com/logrusorgru/aurora"
 )
 
 const (
@@ -62,7 +62,7 @@ func (q *Qliksense) SetSecrets(args []string, isSecretSet bool, base64Encoded bo
 	}
 
 	// Metadata name in qliksense CR is the name of the current context
-	api.LogDebugMessage("Current context: %s", qliksenseCR.GetName())
+	api.LogDebugMessage("Current context: %s\n", qliksenseCR.GetName())
 	encryptionKey, err := qConfig.GetEncryptionKeyForCurrent()
 	if err != nil {
 		return err
@@ -72,7 +72,7 @@ func (q *Qliksense) SetSecrets(args []string, isSecretSet bool, base64Encoded bo
 		return err
 	}
 	for _, ra := range resultArgs {
-		api.LogDebugMessage("value args to be encrypted: %s", ra.Value)
+		api.LogDebugMessage("value args to be encrypted: %s\n", ra.Value)
 		if err := q.processSecret(ra, encryptionKey, qliksenseCR, isSecretSet); err != nil {
 			return err
 		}
@@ -411,7 +411,7 @@ func (q *Qliksense) DeleteContextConfig(args []string, flag bool) error {
 		out := ansi.NewColorableStdout()
 		switch args[0] {
 		case qliksenseConfig.Spec.CurrentContext:
-			fmt.Fprintln(out,Yellow("Please switch contexts to be able to delete this context."))
+			fmt.Fprintln(out, Yellow("Please switch contexts to be able to delete this context."))
 			err := fmt.Errorf(Red("Cannot delete current context - %s").String(), White(Bold(qliksenseConfig.Spec.CurrentContext)))
 			return err
 		case DefaultQliksenseContext:
@@ -452,7 +452,7 @@ func (q *Qliksense) DeleteContextConfig(args []string, flag bool) error {
 						if ans == true {
 							api.WriteToFile(&qliksenseConfig, qliksenseConfigFile)
 							fmt.Fprintln(out, Yellow(Underline("Warning: Active resources may still be running in-cluster")))
-							fmt.Fprintln(out, Green("Successfully deleted context: "),Bold(args[0]))
+							fmt.Fprintln(out, Green("Successfully deleted context: "), Bold(args[0]))
 						} else {
 							return nil
 						}


### PR DESCRIPTION
Preflight mongo mutual tls check:

I am currently adding rootCA into the CR like this:
`cat ~/ca.crt | base64 | qliksense config set-secrets qliksense.caCertificates --base64`

adding client cert into CR like this:
`cat ~/client.pem | base64 | qliksense config set-secrets qliksense.mongoDbClientCrt --base64`

then run:
`qliksense preflight mongo -v`