### PR TITLE
Preflight mongo tls- ca-cert and client-cert in one file

### DIFF
--- a/cmd/qliksense/preflight.go
+++ b/cmd/qliksense/preflight.go
@@ -337,7 +337,7 @@ func pfCreateServiceAccountCheckCmd(q *qliksense.Qliksense) *cobra.Command {
 
 	var preflightServiceAccountCmd = &cobra.Command{
 		Use:     "serviceaccount",
-		Short:   "preflight create ServiceAccount check",
+		Short:   "preflight create serviceaccount check",
 		Long:    `perform preflight serviceaccount check to ensure we are able to create a service account in the cluster`,
 		Example: `qliksense preflight serviceaccount`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/qliksense/preflight.go
+++ b/cmd/qliksense/preflight.go
@@ -152,7 +152,7 @@ func pfDeploymentCheckCmd(q *qliksense.Qliksense) *cobra.Command {
 	}
 	var pfDeploymentCheckCmd = &cobra.Command{
 		Use:     "deployment",
-		Short:   "perform preflight deploymwnt check",
+		Short:   "perform preflight deployment check",
 		Long:    `perform preflight deployment check to ensure that we can create deployments in the cluster`,
 		Example: `qliksense preflight deployment`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/docs/preflight_checks.md
+++ b/docs/preflight_checks.md
@@ -200,8 +200,8 @@ We can check if we are able to connect to an instance of mongodb on the cluster 
 qliksense preflight mongo --url=<url> -v OR
 qliksense preflight mongo -v
 qliksense preflight mongo --url=<mongo-server url> --ca-cert=<path to ca-cert file> -v
-
-
+```
+```shell
 Preflight mongo check
 ---------------------
 Preflight mongodb check: 
@@ -217,7 +217,29 @@ Deleted pod: pf-mongo-pod
 Completed preflight mongodb check
 ```
 
+#### Mongodb check with mutual tls
+In order to perform mutual tls with mongo we need to:
+- append client certificate to the beginning/end of CA certificate. Make sure to include the beginning and end tags on each certificate. 
+The CA certificate file should look like this in the end:
+```shell
+<existing contents of CA cert>
+...
+-----BEGIN RSA PRIVATE KEY-----
+<private key>
+-----END RSA PRIVATE KEY-----
+-----BEGIN CERTIFICATE-----
+<public key>
+-----END CERTIFICATE-----
+```
+- Run the command below to set the ca certificate into the CR
+```shell
+cat <path_to_ca.crt> | base64 | qliksense config set-secrets qliksense.caCertificates --base64
+```
 
+Next, run: 
+```shell
+qliksense preflight mongo -v
+```
 
 ### Running all checks
 Run the command shown below to execute all preflight checks.

--- a/docs/preflight_checks.md
+++ b/docs/preflight_checks.md
@@ -16,9 +16,18 @@ Examples:
 qliksense preflight <preflight_check_to_run>
 
 Available Commands:
-  all         perform all checks
-  dns         perform preflight dns check
-  k8s-version check k8s version
+  all            perform all checks
+  authcheck      preflight authcheck
+  clean          perform preflight clean
+  deployment     perform preflight deploymwnt check
+  dns            perform preflight dns check
+  kube-version   check kubernetes version
+  mongo          preflight mongo OR preflight mongo --url=<url>
+  pod            perform preflight pod check
+  role           preflight create role check
+  rolebinding    preflight create rolebinding check
+  service        perform preflight service check
+  serviceaccount preflight create ServiceAccount check
 
 Flags:
   -h, --help   help for preflight

--- a/docs/preflight_checks.md
+++ b/docs/preflight_checks.md
@@ -19,7 +19,7 @@ Available Commands:
   all            perform all checks
   authcheck      preflight authcheck
   clean          perform preflight clean
-  deployment     perform preflight deploymwnt check
+  deployment     perform preflight deployment check
   dns            perform preflight dns check
   kube-version   check kubernetes version
   mongo          preflight mongo OR preflight mongo --url=<url>

--- a/pkg/preflight/preflight_utils.go
+++ b/pkg/preflight/preflight_utils.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/mitchellh/go-homedir"
-	"github.com/pkg/errors"
 	"github.com/qlik-oss/sense-installer/pkg/api"
 	"github.com/qlik-oss/sense-installer/pkg/qliksense"
 	appsv1 "k8s.io/api/apps/v1"
@@ -115,13 +114,13 @@ func getK8SClientSet(kubeconfig []byte, contextName string) (*kubernetes.Clients
 	if len(kubeconfig) == 0 {
 		clientConfig, err = rest.InClusterConfig()
 		if err != nil {
-			err = errors.Wrap(err, "Unable to load in-cluster kubeconfig")
+			err = fmt.Errorf("Unable to load in-cluster kubeconfig: %w", err)
 			return nil, nil, err
 		}
 	} else {
 		config, err := clientcmd.Load(kubeconfig)
 		if err != nil {
-			err = errors.Wrap(err, "Unable to load kubeconfig")
+			err = fmt.Errorf("Unable to load kubeconfig: %w", err)
 			return nil, nil, err
 		}
 		if contextName != "" {
@@ -129,13 +128,13 @@ func getK8SClientSet(kubeconfig []byte, contextName string) (*kubernetes.Clients
 		}
 		clientConfig, err = clientcmd.NewDefaultClientConfig(*config, &clientcmd.ConfigOverrides{}).ClientConfig()
 		if err != nil {
-			err = errors.Wrap(err, "Unable to create client config from config")
+			err = fmt.Errorf("Unable to create client config from config: %w", err)
 			return nil, nil, err
 		}
 	}
 	clientset, err := kubernetes.NewForConfig(clientConfig)
 	if err != nil {
-		err = errors.Wrap(err, "Unable to create clientset")
+		err = fmt.Errorf("Unable to create clientset: %w", err)
 		return nil, nil, err
 	}
 	return clientset, clientConfig, nil
@@ -186,7 +185,7 @@ func (qp *QliksensePreflight) createPreflightTestDeployment(clientset *kubernete
 		result, err = deploymentsClient.Create(deployment)
 		return err
 	}); err != nil {
-		err = errors.Wrapf(err, "unable to create deployments in the %s namespace", namespace)
+		err = fmt.Errorf("unable to create deployments in the %s namespace: %w", namespace, err)
 		return nil, err
 	}
 	qp.P.LogVerboseMessage("Created deployment %q\n", result.GetObjectMeta().GetName())
@@ -201,7 +200,7 @@ func getDeployment(clientset *kubernetes.Clientset, namespace, depName string) (
 		deployment, err = deploymentsClient.Get(depName, v1.GetOptions{})
 		return err
 	}); err != nil {
-		err = errors.Wrapf(err, "unable to get deployments in the %s namespace", namespace)
+		err = fmt.Errorf("unable to get deployments in the %s namespace: %w", namespace, err)
 		api.LogDebugMessage("%v\n", err)
 		return nil, err
 	}
@@ -271,7 +270,7 @@ func getService(clientset *kubernetes.Clientset, namespace, svcName string) (*ap
 		svc, err = servicesClient.Get(svcName, v1.GetOptions{})
 		return err
 	}); err != nil {
-		err = errors.Wrapf(err, "unable to get services in the %s namespace", namespace)
+		err = fmt.Errorf("unable to get services in the %s namespace: %w", namespace, err)
 		return nil, err
 	}
 


### PR DESCRIPTION
- Supply ca-cert and client-cert as part of one file
- Fixed issue: `dont use github/pkg/errors`  (#85)