### PR TITLE
Preflight mongo mutual tls

### DIFF
--- a/cmd/qliksense/preflight.go
+++ b/cmd/qliksense/preflight.go
@@ -136,12 +136,7 @@ func pfAllChecksCmd(q *qliksense.Qliksense) *cobra.Command {
 	f := preflightAllChecksCmd.Flags()
 	f.BoolVarP(&preflightOpts.Verbose, "verbose", "v", false, "verbose mode")
 	f.StringVarP(&preflightOpts.MongoOptions.MongodbUrl, "mongodb-url", "", "", "mongodbUrl to try connecting to")
-	f.StringVarP(&preflightOpts.MongoOptions.Username, "mongodb-username", "", "", "username to connect to mongodb")
-	f.StringVarP(&preflightOpts.MongoOptions.Password, "mongodb-password", "", "", "password to connect to mongodb")
 	f.StringVarP(&preflightOpts.MongoOptions.CaCertFile, "mongodb-ca-cert", "", "", "certificate to use for mongodb check")
-	f.StringVarP(&preflightOpts.MongoOptions.ClientCertFile, "mongodb-client-cert", "", "", "client-certificate to use for mongodb check")
-	f.BoolVar(&preflightOpts.MongoOptions.Tls, "mongodb-tls", false, "enable tls?")
-
 	return preflightAllChecksCmd
 }
 
@@ -434,11 +429,7 @@ func pfMongoCheckCmd(q *qliksense.Qliksense) *cobra.Command {
 	f := preflightMongoCmd.Flags()
 	f.BoolVarP(&preflightOpts.Verbose, "verbose", "v", false, "verbose mode")
 	f.StringVarP(&preflightOpts.MongoOptions.MongodbUrl, "url", "", "", "mongodbUrl to try connecting to")
-	f.StringVarP(&preflightOpts.MongoOptions.Username, "username", "", "", "username to connect to mongodb")
-	f.StringVarP(&preflightOpts.MongoOptions.Password, "password", "", "", "password to connect to mongodb")
 	f.StringVarP(&preflightOpts.MongoOptions.CaCertFile, "ca-cert", "", "", "ca certificate to use for mongodb check")
-	f.StringVarP(&preflightOpts.MongoOptions.ClientCertFile, "client-cert", "", "", "client-certificate to use for mongodb check")
-	f.BoolVar(&preflightOpts.MongoOptions.Tls, "tls", false, "enable tls?")
 	return preflightMongoCmd
 }
 

--- a/cmd/qliksense/preflight.go
+++ b/cmd/qliksense/preflight.go
@@ -337,7 +337,7 @@ func pfCreateServiceAccountCheckCmd(q *qliksense.Qliksense) *cobra.Command {
 
 	var preflightServiceAccountCmd = &cobra.Command{
 		Use:     "serviceaccount",
-		Short:   "preflight create ServiceAccount check",
+		Short:   "preflight create serviceaccount check",
 		Long:    `perform preflight serviceaccount check to ensure we are able to create a service account in the cluster`,
 		Example: `qliksense preflight serviceaccount`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/qliksense/preflight.go
+++ b/cmd/qliksense/preflight.go
@@ -152,7 +152,7 @@ func pfDeploymentCheckCmd(q *qliksense.Qliksense) *cobra.Command {
 	}
 	var pfDeploymentCheckCmd = &cobra.Command{
 		Use:     "deployment",
-		Short:   "perform preflight deploymwnt check",
+		Short:   "perform preflight deployment check",
 		Long:    `perform preflight deployment check to ensure that we can create deployments in the cluster`,
 		Example: `qliksense preflight deployment`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/docs/preflight_checks.md
+++ b/docs/preflight_checks.md
@@ -200,8 +200,8 @@ We can check if we are able to connect to an instance of mongodb on the cluster 
 qliksense preflight mongo --url=<url> -v OR
 qliksense preflight mongo -v
 qliksense preflight mongo --url=<mongo-server url> --ca-cert=<path to ca-cert file> -v
-
-
+```
+```shell
 Preflight mongo check
 ---------------------
 Preflight mongodb check: 
@@ -217,7 +217,29 @@ Deleted pod: pf-mongo-pod
 Completed preflight mongodb check
 ```
 
+#### Mongodb check with mutual tls
+In order to perform mutual tls with mongo we need to:
+- append client certificate to the beginning/end of CA certificate. Make sure to include the beginning and end tags on each certificate. 
+The CA certificate file should look like this in the end:
+```shell
+<existing contents of CA cert>
+...
+-----BEGIN RSA PRIVATE KEY-----
+<private key>
+-----END RSA PRIVATE KEY-----
+-----BEGIN CERTIFICATE-----
+<public key>
+-----END CERTIFICATE-----
+```
+- Run the command below to set the ca certificate into the CR
+```shell
+cat <path_to_ca.crt> | base64 | qliksense config set-secrets qliksense.caCertificates --base64
+```
 
+Next, run: 
+```shell
+qliksense preflight mongo -v
+```
 
 ### Running all checks
 Run the command shown below to execute all preflight checks.

--- a/docs/preflight_checks.md
+++ b/docs/preflight_checks.md
@@ -16,9 +16,18 @@ Examples:
 qliksense preflight <preflight_check_to_run>
 
 Available Commands:
-  all         perform all checks
-  dns         perform preflight dns check
-  k8s-version check k8s version
+  all            perform all checks
+  authcheck      preflight authcheck
+  clean          perform preflight clean
+  deployment     perform preflight deploymwnt check
+  dns            perform preflight dns check
+  kube-version   check kubernetes version
+  mongo          preflight mongo OR preflight mongo --url=<url>
+  pod            perform preflight pod check
+  role           preflight create role check
+  rolebinding    preflight create rolebinding check
+  service        perform preflight service check
+  serviceaccount preflight create ServiceAccount check
 
 Flags:
   -h, --help   help for preflight

--- a/docs/preflight_checks.md
+++ b/docs/preflight_checks.md
@@ -19,7 +19,7 @@ Available Commands:
   all            perform all checks
   authcheck      preflight authcheck
   clean          perform preflight clean
-  deployment     perform preflight deploymwnt check
+  deployment     perform preflight deployment check
   dns            perform preflight dns check
   kube-version   check kubernetes version
   mongo          preflight mongo OR preflight mongo --url=<url>

--- a/pkg/api/preflight_apis.go
+++ b/pkg/api/preflight_apis.go
@@ -133,6 +133,6 @@ func (p *PreflightConfig) Initialize() error {
 	p.AddMinMongoV("3.6")
 	p.AddImage("nginx", "nginx")
 	p.AddImage("netcat", "subfuzion/netcat")
-	p.AddImage("preflight-mongo", "ashwathisshiva/preflight-mongo")
+	p.AddImage("preflight-mongo", "qlik-docker-oss.bintray.io/preflight-mongo")
 	return p.Write()
 }

--- a/pkg/api/preflight_apis.go
+++ b/pkg/api/preflight_apis.go
@@ -133,6 +133,6 @@ func (p *PreflightConfig) Initialize() error {
 	p.AddMinMongoV("3.6")
 	p.AddImage("nginx", "nginx")
 	p.AddImage("netcat", "subfuzion/netcat")
-	p.AddImage("mongo", "mongo")
+	p.AddImage("preflight-mongo", "ashwathisshiva/preflight-mongo")
 	return p.Write()
 }

--- a/pkg/preflight/preflight_utils.go
+++ b/pkg/preflight/preflight_utils.go
@@ -465,13 +465,13 @@ func waitForPod(clientset *kubernetes.Clientset, namespace string, pod *apiv1.Po
 	}
 	validateFunc := func(data interface{}) bool {
 		po := data.(*apiv1.Pod)
-		return len(po.Status.ContainerStatuses) > 0 && po.Status.ContainerStatuses[0].Ready
+		return po.Status.Phase == apiv1.PodRunning || po.Status.Phase == apiv1.PodSucceeded || po.Status.Phase == apiv1.PodFailed
 	}
 
 	if err := waitForResource(checkFunc, validateFunc); err != nil {
 		return err
 	}
-	if len(pod.Status.ContainerStatuses) == 0 || !pod.Status.ContainerStatuses[0].Ready {
+	if pod.Status.Phase != apiv1.PodRunning && pod.Status.Phase != apiv1.PodSucceeded && pod.Status.Phase != apiv1.PodFailed {
 		err = fmt.Errorf("container is taking much longer than expected")
 		return err
 	}

--- a/pkg/preflight/preflight_utils.go
+++ b/pkg/preflight/preflight_utils.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/mitchellh/go-homedir"
-	"github.com/pkg/errors"
 	"github.com/qlik-oss/sense-installer/pkg/api"
 	"github.com/qlik-oss/sense-installer/pkg/qliksense"
 	appsv1 "k8s.io/api/apps/v1"
@@ -115,13 +114,13 @@ func getK8SClientSet(kubeconfig []byte, contextName string) (*kubernetes.Clients
 	if len(kubeconfig) == 0 {
 		clientConfig, err = rest.InClusterConfig()
 		if err != nil {
-			err = errors.Wrap(err, "Unable to load in-cluster kubeconfig")
+			err = fmt.Errorf("Unable to load in-cluster kubeconfig: %w", err)
 			return nil, nil, err
 		}
 	} else {
 		config, err := clientcmd.Load(kubeconfig)
 		if err != nil {
-			err = errors.Wrap(err, "Unable to load kubeconfig")
+			err = fmt.Errorf("Unable to load kubeconfig: %w", err)
 			return nil, nil, err
 		}
 		if contextName != "" {
@@ -129,13 +128,13 @@ func getK8SClientSet(kubeconfig []byte, contextName string) (*kubernetes.Clients
 		}
 		clientConfig, err = clientcmd.NewDefaultClientConfig(*config, &clientcmd.ConfigOverrides{}).ClientConfig()
 		if err != nil {
-			err = errors.Wrap(err, "Unable to create client config from config")
+			err = fmt.Errorf("Unable to create client config from config: %w", err)
 			return nil, nil, err
 		}
 	}
 	clientset, err := kubernetes.NewForConfig(clientConfig)
 	if err != nil {
-		err = errors.Wrap(err, "Unable to create clientset")
+		err = fmt.Errorf("Unable to create clientset: %w", err)
 		return nil, nil, err
 	}
 	return clientset, clientConfig, nil
@@ -186,7 +185,7 @@ func (qp *QliksensePreflight) createPreflightTestDeployment(clientset *kubernete
 		result, err = deploymentsClient.Create(deployment)
 		return err
 	}); err != nil {
-		err = errors.Wrapf(err, "unable to create deployments in the %s namespace", namespace)
+		err = fmt.Errorf("unable to create deployments in the %s namespace: %w", namespace, err)
 		return nil, err
 	}
 	qp.P.LogVerboseMessage("Created deployment %q\n", result.GetObjectMeta().GetName())
@@ -201,7 +200,7 @@ func getDeployment(clientset *kubernetes.Clientset, namespace, depName string) (
 		deployment, err = deploymentsClient.Get(depName, v1.GetOptions{})
 		return err
 	}); err != nil {
-		err = errors.Wrapf(err, "unable to get deployments in the %s namespace", namespace)
+		err = fmt.Errorf("unable to get deployments in the %s namespace: %w", namespace, err)
 		api.LogDebugMessage("%v\n", err)
 		return nil, err
 	}
@@ -271,7 +270,7 @@ func getService(clientset *kubernetes.Clientset, namespace, svcName string) (*ap
 		svc, err = servicesClient.Get(svcName, v1.GetOptions{})
 		return err
 	}); err != nil {
-		err = errors.Wrapf(err, "unable to get services in the %s namespace", namespace)
+		err = fmt.Errorf("unable to get services in the %s namespace: %w", namespace, err)
 		return nil, err
 	}
 

--- a/pkg/qliksense/docker_test.go
+++ b/pkg/qliksense/docker_test.go
@@ -245,7 +245,7 @@ spec:
 		t.Fatal("expected to find the netcat Preflight image in the list, but it wasn't there")
 	}
 	if !haveMatchingImage(func(image string) bool {
-		return image == "ashwathisshiva/preflight-mongo"
+		return image == "qlik-docker-oss.bintray.io/preflight-mongo"
 	}) {
 		t.Fatal("expected to find the mongo Preflight image in the list, but it wasn't there")
 	}

--- a/pkg/qliksense/docker_test.go
+++ b/pkg/qliksense/docker_test.go
@@ -245,7 +245,7 @@ spec:
 		t.Fatal("expected to find the netcat Preflight image in the list, but it wasn't there")
 	}
 	if !haveMatchingImage(func(image string) bool {
-		return image == "mongo"
+		return image == "ashwathisshiva/preflight-mongo"
 	}) {
 		t.Fatal("expected to find the mongo Preflight image in the list, but it wasn't there")
 	}


### PR DESCRIPTION
Will not accept client certificate as part of the preflight mongo command anymore. 

- Mongodb url and ca-cert are the only things the check will accept: `qliksense preflight mongo --url="<mongodb-url>" `
- If available, mongodb url and certs are inferred from CR: `qliksense preflight mongo -v`