### PR TITLE
add unset command

### DIFF
--- a/cmd/qliksense/context.go
+++ b/cmd/qliksense/context.go
@@ -220,3 +220,20 @@ func cleanConfigRepoPatchesCmd(q *qliksense.Qliksense) *cobra.Command {
 		},
 	}
 }
+
+func unsetCmd(q *qliksense.Qliksense) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "unset",
+		Short: "remove a key from a context or a secrets or a configs from the context",
+		Example: `
+		qliksense config unset <key> # remove the key from CR, supports space separated multiple arguments
+		qliksense config unset <service>.<key> # remove the key from service inside configs/secrets of CR 
+		qliksense config usnet <servcie> # remove the service from inside configs/secrets of CR
+		`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return q.UnsetCmd(args)
+		},
+		Args: cobra.MinimumNArgs(1),
+	}
+	return cmd
+}

--- a/cmd/qliksense/context.go
+++ b/cmd/qliksense/context.go
@@ -226,10 +226,17 @@ func unsetCmd(q *qliksense.Qliksense) *cobra.Command {
 		Use:   "unset",
 		Short: "remove a key from a context or a secrets or a configs from the context",
 		Example: `
-		qliksense config unset <key> # remove the key from CR, supports space separated multiple arguments
-		qliksense config unset <service>.<key> # remove the key from service inside configs/secrets of CR 
-		qliksense config usnet <servcie> # remove the service from inside configs/secrets of CR
-		`,
+# remove the key from CR
+qliksense config unset <key>
+
+# remove the key from service inside configs/secrets of CR
+qliksense config unset <service>.<key> 
+
+# remove the service from inside configs/secrets of CR
+qliksense config usnet <servcie> 
+
+all of the above supports space separated multiple arguments
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return q.UnsetCmd(args)
 		},

--- a/cmd/qliksense/root.go
+++ b/cmd/qliksense/root.go
@@ -122,6 +122,7 @@ func getRootCmd(p *qliksense.Qliksense) *cobra.Command {
 				globalEulaPostRun(cmd, p)
 			}
 		},
+		SilenceUsage: true,
 	}
 	origHelpFunc := cmd.HelpFunc()
 	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
@@ -198,6 +199,10 @@ func rootCmd(p *qliksense.Qliksense) *cobra.Command {
 
 	// open editor for config
 	configCmd.AddCommand(configEditCmd(p))
+
+	// add unset for config
+	configCmd.AddCommand((unsetCmd(p)))
+
 	// add uninstall command
 	cmd.AddCommand(uninstallCmd(p))
 

--- a/pkg/qliksense/context_configs_unset.go
+++ b/pkg/qliksense/context_configs_unset.go
@@ -1,0 +1,109 @@
+package qliksense
+
+import (
+	"fmt"
+	"strings"
+
+	"reflect"
+
+	kconfig "github.com/qlik-oss/k-apis/pkg/config"
+	"github.com/qlik-oss/sense-installer/pkg/api"
+)
+
+func (q *Qliksense) UnsetCmd(args []string) error {
+	return unsetAll(q.QliksenseHome, args)
+}
+func unsetAll(qHome string, args []string) error {
+	qConfig := api.NewQConfig(qHome)
+
+	qcr, err := qConfig.GetCurrentCR()
+	if err != nil {
+		return err
+	}
+
+	// either delete all args or none
+	for _, arg := range args {
+		isRemoved := false
+		// delete if key present
+		if !strings.Contains(arg, ".") {
+			if isRemoved = unsetOnlyKey(arg, qcr); isRemoved {
+				//continue to the next arg
+				continue
+			} else if isRemoved = unsetServiceName(arg, qcr); isRemoved {
+				//continue to the next arg
+				continue
+			} else {
+				return fmt.Errorf("%s not found in the context", arg)
+			}
+		}
+		// delete key inside configs if present
+		// delete key inside secrets if present
+		if isRemoved = unsetServiceKey(arg, qcr); !isRemoved {
+			return fmt.Errorf("%s not found in the context", arg)
+		}
+	}
+
+	return qConfig.WriteCR(qcr)
+}
+func unsetOnlyKey(key string, qcr *api.QliksenseCR) bool {
+
+	v := reflect.ValueOf(qcr.Spec).Elem().FieldByName(strings.Title(key))
+	if v.IsValid() && v.CanSet() {
+		v.SetString("")
+		return true
+	}
+	return false
+}
+
+func unsetServiceName(svc string, qcr *api.QliksenseCR) bool {
+	if qcr.Spec.Configs != nil && qcr.Spec.Configs[svc] != nil {
+		delete(qcr.Spec.Configs, svc)
+		return true
+	}
+
+	if qcr.Spec.Secrets != nil && qcr.Spec.Secrets[svc] != nil {
+		delete(qcr.Spec.Secrets, svc)
+		return true
+	}
+	return false
+}
+
+func unsetServiceKey(svcKey string, qcr *api.QliksenseCR) bool {
+	sk := strings.Split(svcKey, ".")
+	svc := sk[0]
+	key := sk[1]
+
+	if qcr.Spec.Configs != nil && qcr.Spec.Configs[svc] != nil {
+		index := findIndex(key, qcr.Spec.Configs[svc])
+		if index > -1 {
+			qcr.Spec.Configs[svc][index] = qcr.Spec.Configs[svc][len(qcr.Spec.Configs[svc])-1]
+			qcr.Spec.Configs[svc] = qcr.Spec.Configs[svc][:len(qcr.Spec.Configs[svc])-1]
+			if len(qcr.Spec.Configs[svc]) == 0 {
+				delete(qcr.Spec.Configs, svc)
+			}
+			return true
+		}
+	}
+
+	if qcr.Spec.Secrets != nil && qcr.Spec.Secrets[svc] != nil {
+		index := findIndex(key, qcr.Spec.Secrets[svc])
+		if index > -1 {
+			qcr.Spec.Secrets[svc][index] = qcr.Spec.Secrets[svc][len(qcr.Spec.Secrets[svc])-1]
+			qcr.Spec.Secrets[svc] = qcr.Spec.Secrets[svc][:len(qcr.Spec.Secrets[svc])-1]
+			if len(qcr.Spec.Secrets[svc]) == 0 {
+				delete(qcr.Spec.Secrets, svc)
+			}
+			return true
+		}
+	}
+	return false
+}
+
+func findIndex(elem string, nvs kconfig.NameValues) int {
+	for i, nv := range nvs {
+		if nv.Name == elem {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/qliksense/context_configs_unset_test.go
+++ b/pkg/qliksense/context_configs_unset_test.go
@@ -1,0 +1,99 @@
+package qliksense
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/qlik-oss/sense-installer/pkg/api"
+	_ "gopkg.in/yaml.v2"
+)
+
+func TestUnsetAll(t *testing.T) {
+	qHome, _ := ioutil.TempDir("", "")
+	testPepareDir(qHome)
+	defer os.RemoveAll(qHome)
+	//fmt.Print(qHome)
+	args := []string{"rotateKeys", "qliksense", "qliksense2.acceptEula3", "serviceA.acceptEula"}
+	if err := unsetAll(qHome, args); err != nil {
+		t.Log("error during unset", err)
+		t.FailNow()
+	}
+	qc := api.NewQConfig(qHome)
+	qcr, err := qc.GetCurrentCR()
+	if err != nil {
+		t.Log("error while getting current cr", err)
+		t.FailNow()
+	}
+	if qcr.Spec.RotateKeys != "" {
+		t.Log("Expected empty rotateKeys but got: " + qcr.Spec.RotateKeys)
+		t.Fail()
+	}
+
+	if qcr.Spec.Configs["qliksense"] != nil {
+		t.Log("qliksense in configs not deleted")
+		t.Fail()
+	}
+	if len(qcr.Spec.Configs["qliksense2"]) != 1 {
+		t.Log("qliksense2.acceptEula3 not deleted")
+		t.Fail()
+	}
+	if qcr.Spec.Configs["serviceA"] != nil {
+		t.Log("serviceA not deleted")
+		t.Fail()
+	}
+}
+
+func testPepareDir(qHome string) {
+
+	config :=
+		`
+apiVersion: config.qlik.com/v1
+kind: QliksenseConfig
+metadata:
+  name: qliksenseConfig
+spec:
+  contexts:
+  - name: qlik-default
+    crFile: contexts/qlik-default/qlik-default.yaml
+  currentContext: qlik-default
+`
+	configFile := filepath.Join(qHome, "config.yaml")
+	// tests/config.yaml exists
+	ioutil.WriteFile(configFile, []byte(config), 0777)
+
+	contextYaml :=
+		`
+apiVersion: qlik.com/v1
+kind: Qliksense
+metadata:
+  name: qlik-default
+spec:
+  profile: docker-desktop
+  rotateKeys: "yes"
+  configs:
+    qliksense:
+    - name: acceptEula
+      value: some
+    qliksense2:
+    - name: acceptEula2
+      value: some
+    - name: acceptEula3
+      value: some
+    serviceA:
+    - name: acceptEula
+      value: some
+`
+	qlikDefaultContext := "qlik-default"
+	// create contexts/qlik-default/ under tests/
+	contexts := "contexts"
+	contextsDir := filepath.Join(qHome, contexts, qlikDefaultContext)
+	if err := os.MkdirAll(contextsDir, 0777); err != nil {
+		err = fmt.Errorf("Not able to create directories")
+	}
+
+	contextFile := filepath.Join(contextsDir, qlikDefaultContext+".yaml")
+	ioutil.WriteFile(contextFile, []byte(contextYaml), 0777)
+}


### PR DESCRIPTION
Signed-off-by: Foysal Iqbal <mqb@qlik.com>

```
# remove the key from CR
qliksense config unset <key>

# remove the key from service inside configs/secrets of CR
qliksense config unset <service>.<key> 

# remove the service from inside configs/secrets of CR
qliksense config usnet <servcie> 

all of the above supports space separated multiple arguments
```
TODO: https://github.com/qlik-oss/sense-installer/issues/380