### PR TITLE
Dry run and fix mongo

### DIFF
--- a/cmd/qliksense/apply.go
+++ b/cmd/qliksense/apply.go
@@ -37,7 +37,7 @@ func applyCmd(q *qliksense.Qliksense) *cobra.Command {
 	f.StringVarP(&filePath, "file", "f", "", "Install from a CR file")
 	c.MarkFlagRequired("file")
 	f.StringVarP(&opts.StorageClass, "storageClass", "s", "", "Storage class for qliksense")
-	f.StringVarP(&opts.MongoDbUri, "mongoDbUri", "m", "", "mongoDbUri for qliksense (i.e. mongodb://qlik-default-mongodb:27017/qliksense?ssl=false)")
+	f.StringVarP(&opts.MongodbUri, "mongodbUri", "m", "", "mongodbUri for qliksense (i.e. mongodb://qlik-default-mongodb:27017/qliksense?ssl=false)")
 	f.StringVarP(&opts.RotateKeys, "rotateKeys", "r", "", "Rotate JWT keys for qliksense (yes:rotate keys/ no:use exising keys from cluster/ None: use default EJSON_KEY from env")
 	f.BoolVar(&keepPatchFiles, keepPatchFilesFlagName, keepPatchFiles, keepPatchFilesFlagUsage)
 	f.BoolVarP(&pull, pullFlagName, pullFlagShorthand, pull, pullFlagUsage)

--- a/cmd/qliksense/install.go
+++ b/cmd/qliksense/install.go
@@ -71,7 +71,7 @@ func installCmd(q *qliksense.Qliksense) *cobra.Command {
 
 	f := c.Flags()
 	f.StringVarP(&opts.StorageClass, "storageClass", "s", "", "Storage class for qliksense")
-	f.StringVarP(&opts.MongoDbUri, "mongoDbUri", "m", "", "mongoDbUri for qliksense (i.e. mongodb://qlik-default-mongodb:27017/qliksense?ssl=false)")
+	f.StringVarP(&opts.MongodbUri, "mongodbUri", "m", "", "mongodbUri for qliksense (i.e. mongodb://qlik-default-mongodb:27017/qliksense?ssl=false)")
 	f.StringVarP(&opts.RotateKeys, "rotateKeys", "r", "", "Rotate JWT keys for qliksense (yes:rotate keys/ no:use exising keys from cluster/ None: use default EJSON_KEY from env")
 	f.BoolVar(&keepPatchFiles, keepPatchFilesFlagName, keepPatchFiles, keepPatchFilesFlagUsage)
 	f.StringVarP(&filePath, "file", "f", "", "Install from a CR file")

--- a/cmd/qliksense/install.go
+++ b/cmd/qliksense/install.go
@@ -76,6 +76,8 @@ func installCmd(q *qliksense.Qliksense) *cobra.Command {
 	f.BoolVar(&keepPatchFiles, keepPatchFilesFlagName, keepPatchFiles, keepPatchFilesFlagUsage)
 	f.StringVarP(&filePath, "file", "f", "", "Install from a CR file")
 
+	f.BoolVarP(&opts.DryRun, "dry-run", "", false, "Dry run will generate the patches without rotating keys")
+
 	f.BoolVarP(&pull, pullFlagName, pullFlagShorthand, pull, pullFlagUsage)
 	f.BoolVarP(&push, pushFlagName, pushFlagShorthand, push, pushFlagUsage)
 

--- a/docs/command_reference.md
+++ b/docs/command_reference.md
@@ -63,7 +63,7 @@ spec:
       value: "yes"
   secrets:
     qliksense:
-    - name: mongoDbUri
+    - name: mongodbUri
       value: mongodb://qlik-test-mongodb:27017/qliksense?ssl=false
   profile: docker-desktop
   rotateKeys: "yes"
@@ -104,7 +104,7 @@ spec:
       value: "yes"
   secrets:
     qliksense:
-    - name: mongoDbUri
+    - name: mongodbUri
       value: "mongo://mongo:3307"
     - name: messagingPassword
       valueFromKey: messagingPassword

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -23,7 +23,7 @@ spec:
   profile: docker-desktop
   secrets:
     qliksense:
-    - name: mongoDbUri
+    - name: mongodbUri
       value: mongodb://qlik-default-mongodb:27017/qliksense?ssl=false
   rotateKeys: "yes"
   releaseName: qlik-default

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/otiai10/copy v1.1.1
 	github.com/pkg/errors v0.9.1
-	github.com/qlik-oss/k-apis v0.1.2
+	github.com/qlik-oss/k-apis v0.1.4
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/rogpeppe/go-internal v1.5.2 // indirect
 	github.com/spf13/cobra v0.0.6

--- a/go.sum
+++ b/go.sum
@@ -885,6 +885,8 @@ github.com/prometheus/procfs v0.0.5/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDa
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/qlik-oss/k-apis v0.1.2 h1:BBcrXl+NxdsvuRsZuJbvIFxMv5QIXqWBzhXOcr5KUX8=
 github.com/qlik-oss/k-apis v0.1.2/go.mod h1:yoYGgPJ/H0t9H3NSq64dWfyQY6QWi2L9c+hCJoVO03U=
+github.com/qlik-oss/k-apis v0.1.4 h1:YXnjKXm/yhPblzYYyVCtD0dNbIkLPLlDdBKnjeYW0IY=
+github.com/qlik-oss/k-apis v0.1.4/go.mod h1:yoYGgPJ/H0t9H3NSq64dWfyQY6QWi2L9c+hCJoVO03U=
 github.com/qlik-oss/kustomize/api v0.3.3-0.20200514233516-4ac83864b7bd h1:dYd6duTr54L7OqykGkd3Z+336frAvzsibWNYruYkYVc=
 github.com/qlik-oss/kustomize/api v0.3.3-0.20200514233516-4ac83864b7bd/go.mod h1:zh3yFgE5zFk1kreqzVyyj1eXyIxQJT53l4zSg8Wt4SA=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=

--- a/pkg/api/apis_test.go
+++ b/pkg/api/apis_test.go
@@ -107,7 +107,7 @@ func TestGetDecryptedCr(t *testing.T) {
 	key, _ := setupGenerateKey(dir)
 	ecn, _ := EncryptData([]byte("mongodb://qlik-default-mongodb:27017/qliksense?ssl=false"), key)
 	b := b64.StdEncoding.EncodeToString(ecn)
-	qcr.Spec.AddToSecrets("qliksense", "mongoDbUri", b, "")
+	qcr.Spec.AddToSecrets("qliksense", "mongodbUri", b, "")
 
 	qcr.SetFetchAccessToken("mytoken", key)
 
@@ -117,8 +117,8 @@ func TestGetDecryptedCr(t *testing.T) {
 		t.Log(err)
 	}
 
-	decryptedValue := newCr.Spec.GetFromSecrets("qliksense", "mongoDbUri")
-	orignalValue := qcr.Spec.GetFromSecrets("qliksense", "mongoDbUri")
+	decryptedValue := newCr.Spec.GetFromSecrets("qliksense", "mongodbUri")
+	orignalValue := qcr.Spec.GetFromSecrets("qliksense", "mongodbUri")
 	if decryptedValue != "mongodb://qlik-default-mongodb:27017/qliksense?ssl=false" {
 		t.Fail()
 		b, _ := K8sToYaml(newCr)

--- a/pkg/api/context_apis.go
+++ b/pkg/api/context_apis.go
@@ -24,8 +24,8 @@ const (
 	QliksenseDefaultProfile = "docker-desktop"
 	DefaultRotateKeys       = "yes"
 	QliksenseMetadataName   = "QliksenseConfigMetadata"
-	DefaultmongodbUri       = "mongodb://qlik-default-mongodb:27017/qliksense?ssl=false"
-	DefaultmongodbUriKey    = "mongodbUri"
+	DefaultMongodbUri       = "mongodb://qlik-default-mongodb:27017/qliksense?ssl=false"
+	DefaultMongodbUriKey    = "mongodbUri"
 )
 
 // AddCommonConfig adds common configs into CRs
@@ -40,7 +40,7 @@ func (qliksenseCR *QliksenseCR) AddCommonConfig(contextName string) {
 		Profile:    QliksenseDefaultProfile,
 		RotateKeys: DefaultRotateKeys,
 	}
-	qliksenseCR.Spec.AddToSecrets("qliksense", DefaultmongodbUriKey, DefaultmongodbUri, "")
+	qliksenseCR.Spec.AddToSecrets("qliksense", DefaultMongodbUriKey, DefaultMongodbUri, "")
 }
 
 // AddBaseQliksenseConfigs adds configs into config.yaml

--- a/pkg/api/context_apis.go
+++ b/pkg/api/context_apis.go
@@ -24,8 +24,8 @@ const (
 	QliksenseDefaultProfile = "docker-desktop"
 	DefaultRotateKeys       = "yes"
 	QliksenseMetadataName   = "QliksenseConfigMetadata"
-	DefaultMongoDbUri       = "mongodb://qlik-default-mongodb:27017/qliksense?ssl=false"
-	DefaultMongoDbUriKey    = "mongoDbUri"
+	DefaultmongodbUri       = "mongodb://qlik-default-mongodb:27017/qliksense?ssl=false"
+	DefaultmongodbUriKey    = "mongodbUri"
 )
 
 // AddCommonConfig adds common configs into CRs
@@ -40,7 +40,7 @@ func (qliksenseCR *QliksenseCR) AddCommonConfig(contextName string) {
 		Profile:    QliksenseDefaultProfile,
 		RotateKeys: DefaultRotateKeys,
 	}
-	qliksenseCR.Spec.AddToSecrets("qliksense", DefaultMongoDbUriKey, DefaultMongoDbUri, "")
+	qliksenseCR.Spec.AddToSecrets("qliksense", DefaultmongodbUriKey, DefaultmongodbUri, "")
 }
 
 // AddBaseQliksenseConfigs adds configs into config.yaml

--- a/pkg/api/context_apis_test.go
+++ b/pkg/api/context_apis_test.go
@@ -26,8 +26,8 @@ func TestAddCommonConfig(t *testing.T) {
 		RotateKeys: DefaultRotateKeys,
 		Secrets: map[string]config.NameValues{
 			"qliksense": []config.NameValue{{
-				Name:  DefaultMongoDbUriKey,
-				Value: DefaultMongoDbUri,
+				Name:  DefaultmongodbUriKey,
+				Value: DefaultmongodbUri,
 			},
 			},
 		},

--- a/pkg/api/context_apis_test.go
+++ b/pkg/api/context_apis_test.go
@@ -26,8 +26,8 @@ func TestAddCommonConfig(t *testing.T) {
 		RotateKeys: DefaultRotateKeys,
 		Secrets: map[string]config.NameValues{
 			"qliksense": []config.NameValue{{
-				Name:  DefaultmongodbUriKey,
-				Value: DefaultmongodbUri,
+				Name:  DefaultMongodbUriKey,
+				Value: DefaultMongodbUri,
 			},
 			},
 		},

--- a/pkg/preflight/mongo_check.go
+++ b/pkg/preflight/mongo_check.go
@@ -41,8 +41,8 @@ func (qp *QliksensePreflight) CheckMongo(kubeConfigContents []byte, namespace st
 	}
 	if preflightOpts.MongoOptions.MongodbUrl == "" && !cleanup {
 		// infer mongoDbUrl from currentCR
-		qp.P.LogVerboseMessage("MongoDbUri is empty, infer from CR\n")
-		preflightOpts.MongoOptions.MongodbUrl = strings.TrimSpace(decryptedCR.Spec.GetFromSecrets("qliksense", "mongoDbUri"))
+		qp.P.LogVerboseMessage("mongodbUri is empty, infer from CR\n")
+		preflightOpts.MongoOptions.MongodbUrl = strings.TrimSpace(decryptedCR.Spec.GetFromSecrets("qliksense", "mongodbUri"))
 	}
 
 	if preflightOpts.MongoOptions.CaCertFile == "" && !cleanup {

--- a/pkg/qliksense/context_configs.go
+++ b/pkg/qliksense/context_configs.go
@@ -522,7 +522,7 @@ func (q *Qliksense) SetUpQliksenseContext(contextName string) error {
 	}
 
 	// set the encrypted default mongo
-	return q.SetSecrets([]string{`qliksense.mongoDbUri="mongodb://qlik-default-mongodb:27017/qliksense?ssl=false"`}, false, false)
+	return q.SetSecrets([]string{`qliksense.mongodbUri="mongodb://qlik-default-mongodb:27017/qliksense?ssl=false"`}, false, false)
 }
 
 func validateInput(input string) (string, error) {

--- a/pkg/qliksense/context_configs_test.go
+++ b/pkg/qliksense/context_configs_test.go
@@ -29,7 +29,7 @@ const (
 var targetFileStringTemplate = `
 apiVersion: v1
 data:
-  mongoDbUri: %s
+  mongodbUri: %s
 kind: Secret
 metadata:
   name: testctx-qliksense-senseinstaller
@@ -296,7 +296,7 @@ func TestSetConfigs(t *testing.T) {
 				q: &Qliksense{
 					QliksenseHome: testDir,
 				},
-				args: []string{"qliksense.acceptEULA=\"yes\"", "qliksense.mongoDbUri=\"mongo://mongo:3307\""},
+				args: []string{"qliksense.acceptEULA=\"yes\"", "qliksense.mongodbUri=\"mongo://mongo:3307\""},
 			},
 			wantErr: false,
 		},
@@ -572,7 +572,7 @@ func Test_SetSecrets(t *testing.T) {
 				QliksenseHome: testDir,
 			},
 			args: args{
-				args:        []string{"qliksense.mongoDbUri=\"mongodb://qlik-default-mongodb:27017/qliksense?ssl=false\""},
+				args:        []string{"qliksense.mongodbUri=\"mongodb://qlik-default-mongodb:27017/qliksense?ssl=false\""},
 				isSecretSet: false,
 			},
 			wantErr: false,
@@ -583,7 +583,7 @@ func Test_SetSecrets(t *testing.T) {
 				QliksenseHome: testDir,
 			},
 			args: args{
-				args:        []string{"qliksense.mongoDbUri=bW9uZ29kYjovL3FsaWstZGVmYXVsdC1tb25nb2RiOjI3MDE3L3FsaWtzZW5zZT9zc2w9ZmFsc2U="},
+				args:        []string{"qliksense.mongodbUri=bW9uZ29kYjovL3FsaWstZGVmYXVsdC1tb25nb2RiOjI3MDE3L3FsaWtzZW5zZT9zc2w9ZmFsc2U="},
 				isSecretSet: false,
 				base64:      true,
 			},
@@ -595,7 +595,7 @@ func Test_SetSecrets(t *testing.T) {
 				QliksenseHome: testDir,
 			},
 			args: args{
-				args:        []string{"qliksense.mongoDbUri=\"mongo://mongo:3307\""},
+				args:        []string{"qliksense.mongodbUri=\"mongo://mongo:3307\""},
 				isSecretSet: true,
 			},
 			wantErr: false,
@@ -606,7 +606,7 @@ func Test_SetSecrets(t *testing.T) {
 				QliksenseHome: testDir,
 			},
 			args: args{
-				args:        []string{"qliksense.mongoDbUri=\"mongodb://qlik-default-mongodb:27017/qliksense?ssl=false\""},
+				args:        []string{"qliksense.mongodbUri=\"mongodb://qlik-default-mongodb:27017/qliksense?ssl=false\""},
 				isSecretSet: true,
 			},
 			wantErr: false,

--- a/pkg/qliksense/install.go
+++ b/pkg/qliksense/install.go
@@ -8,7 +8,9 @@ import (
 	"path"
 	"path/filepath"
 
+	"github.com/mitchellh/go-homedir"
 	"github.com/qlik-oss/k-apis/pkg/config"
+	"github.com/qlik-oss/k-apis/pkg/cr"
 	"sigs.k8s.io/kustomize/api/filesys"
 
 	qapi "github.com/qlik-oss/sense-installer/pkg/api"
@@ -18,6 +20,7 @@ type InstallCommandOptions struct {
 	StorageClass string
 	MongoDbUri   string
 	RotateKeys   string
+	DryRun       bool
 }
 
 func (q *Qliksense) InstallQK8s(version string, opts *InstallCommandOptions, keepPatchFiles bool) error {
@@ -50,6 +53,15 @@ func (q *Qliksense) InstallQK8s(version string, opts *InstallCommandOptions, kee
 	}
 	if opts.RotateKeys != "" {
 		qcr.Spec.RotateKeys = opts.RotateKeys
+	}
+	// for debugging purpose
+	if opts.DryRun {
+		// generate patches
+		qcr.Spec.RotateKeys = "None"
+		userHomeDir, _ := homedir.Dir()
+		fmt.Println("Generating patches only")
+		cr.GeneratePatches(&qcr.KApiCr, path.Join(userHomeDir, ".kube", "config"))
+		return nil
 	}
 	qConfig.WriteCurrentContextCR(qcr)
 

--- a/pkg/qliksense/install.go
+++ b/pkg/qliksense/install.go
@@ -18,7 +18,7 @@ import (
 
 type InstallCommandOptions struct {
 	StorageClass string
-	MongoDbUri   string
+	MongodbUri   string
 	RotateKeys   string
 	DryRun       bool
 }
@@ -45,8 +45,8 @@ func (q *Qliksense) InstallQK8s(version string, opts *InstallCommandOptions, kee
 	}
 
 	qcr.SetEULA("yes")
-	if opts.MongoDbUri != "" {
-		qcr.Spec.AddToSecrets("qliksense", "mongoDbUri", opts.MongoDbUri, "")
+	if opts.MongodbUri != "" {
+		qcr.Spec.AddToSecrets("qliksense", "mongodbUri", opts.MongodbUri, "")
 	}
 	if opts.StorageClass != "" {
 		qcr.Spec.StorageClassName = opts.StorageClass

--- a/pkg/qliksense/install_test.go
+++ b/pkg/qliksense/install_test.go
@@ -43,7 +43,7 @@ spec:
       value: "yes"
   secrets:
     qliksense:
-    - name: mongoDbUri
+    - name: mongodbUri
       value: mongodb://qlik-default-mongodb:27017/qliksense?ssl=false
   profile: docker-desktop
   rotateKeys: "yes"`

--- a/pkg/qliksense/load_cr_test.go
+++ b/pkg/qliksense/load_cr_test.go
@@ -35,7 +35,7 @@ spec:
       value: "yes"
   secrets:
     qliksense:
-    - name: mongoDbUri
+    - name: mongodbUri
       value: mongodb://qlik-default-mongodb:27017/qliksense?ssl=false
   profile: docker-desktop
   rotateKeys: "yes"`
@@ -62,7 +62,7 @@ spec:
       value: "yes"
   secrets:
     qliksense:
-    - name: mongoDbUri
+    - name: mongodbUri
       value: mongodb://qlik-default-mongodb:27017/qliksense?ssl=false
   profile: docker-desktop
   rotateKeys: "yes"`


### PR DESCRIPTION
fix `mongoDbUri` to `mongodbUri`
added `qliksense install --dry-run` to generate patches only
- will not install
- will not rotate keys
- will not decrypt secrets