### PR TITLE
remove git functionality

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/otiai10/copy v1.1.1
 	github.com/pkg/errors v0.9.1
-	github.com/qlik-oss/k-apis v0.1.4
+	github.com/qlik-oss/k-apis v0.1.5
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/rogpeppe/go-internal v1.5.2 // indirect
 	github.com/spf13/cobra v0.0.6

--- a/go.sum
+++ b/go.sum
@@ -889,6 +889,8 @@ github.com/qlik-oss/k-apis v0.1.2 h1:BBcrXl+NxdsvuRsZuJbvIFxMv5QIXqWBzhXOcr5KUX8
 github.com/qlik-oss/k-apis v0.1.2/go.mod h1:yoYGgPJ/H0t9H3NSq64dWfyQY6QWi2L9c+hCJoVO03U=
 github.com/qlik-oss/k-apis v0.1.4 h1:YXnjKXm/yhPblzYYyVCtD0dNbIkLPLlDdBKnjeYW0IY=
 github.com/qlik-oss/k-apis v0.1.4/go.mod h1:yoYGgPJ/H0t9H3NSq64dWfyQY6QWi2L9c+hCJoVO03U=
+github.com/qlik-oss/k-apis v0.1.5 h1:IeqHuF1IIQCsuSmsUhL7GjdfkOFsNgh3z2UyX59GTsk=
+github.com/qlik-oss/k-apis v0.1.5/go.mod h1:yoYGgPJ/H0t9H3NSq64dWfyQY6QWi2L9c+hCJoVO03U=
 github.com/qlik-oss/kustomize/api v0.3.3-0.20200514233516-4ac83864b7bd h1:dYd6duTr54L7OqykGkd3Z+336frAvzsibWNYruYkYVc=
 github.com/qlik-oss/kustomize/api v0.3.3-0.20200514233516-4ac83864b7bd/go.mod h1:zh3yFgE5zFk1kreqzVyyj1eXyIxQJT53l4zSg8Wt4SA=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=

--- a/pkg/qliksense/context_configs.go
+++ b/pkg/qliksense/context_configs.go
@@ -358,8 +358,6 @@ func (q *Qliksense) processSetOpsRunner(arg string, cr *api.QliksenseCR) error {
 		cr.Spec.OpsRunner.WatchBranch = args[1]
 	case "image":
 		cr.Spec.OpsRunner.Image = args[1]
-	case "crPvc":
-		cr.Spec.OpsRunner.CrPvc = args[1]
 	default:
 		return errors.New(arg + " does not match any cr spec")
 	}

--- a/pkg/qliksense/install.go
+++ b/pkg/qliksense/install.go
@@ -93,7 +93,7 @@ func (q *Qliksense) InstallQK8s(version string, opts *InstallCommandOptions, kee
 		return err
 	}
 
-	if qcr.Spec.Git != nil && qcr.Spec.Git.Repository != "" {
+	if qcr.Spec.OpsRunner != nil {
 		// fetching and applying manifest will be in the operator controller
 		// get decrypted cr
 		if dcr, err := qConfig.GetDecryptedCr(qcr); err != nil {


### PR DESCRIPTION
Signed-off-by: Foysal Iqbal <mqb@qlik.com>

since `git` is kind of optional for the operator thats why change the logic a bit