### PR TITLE
Flag rename and typo fix

### DIFF
--- a/cmd/qliksense/apply.go
+++ b/cmd/qliksense/apply.go
@@ -14,7 +14,7 @@ import (
 func applyCmd(q *qliksense.Qliksense) *cobra.Command {
 	opts := &qliksense.InstallCommandOptions{}
 	filePath := ""
-	keepPatchFiles, pull, push := false, false, false
+	cleanPatchFiles, pull, push := true, false, false
 	c := &cobra.Command{
 		Use:     "apply",
 		Short:   "install qliksense based on provided cr file",
@@ -27,7 +27,7 @@ func applyCmd(q *qliksense.Qliksense) *cobra.Command {
 				} else if err := validatePullPushFlagsOnApply(cr, pull, push); err != nil {
 					return err
 				} else {
-					return q.ApplyCRFromReader(bytes.NewReader(crBytesWithEula), opts, keepPatchFiles, true, pull, push)
+					return q.ApplyCRFromReader(bytes.NewReader(crBytesWithEula), opts, cleanPatchFiles, true, pull, push)
 				}
 			})
 		},
@@ -39,7 +39,7 @@ func applyCmd(q *qliksense.Qliksense) *cobra.Command {
 	f.StringVarP(&opts.StorageClass, "storageClass", "s", "", "Storage class for qliksense")
 	f.StringVarP(&opts.MongodbUri, "mongodbUri", "m", "", "mongodbUri for qliksense (i.e. mongodb://qlik-default-mongodb:27017/qliksense?ssl=false)")
 	f.StringVarP(&opts.RotateKeys, "rotateKeys", "r", "", "Rotate JWT keys for qliksense (yes:rotate keys/ no:use exising keys from cluster/ None: use default EJSON_KEY from env")
-	f.BoolVar(&keepPatchFiles, keepPatchFilesFlagName, keepPatchFiles, keepPatchFilesFlagUsage)
+	f.BoolVar(&cleanPatchFiles, cleanPatchFilesFlagName, cleanPatchFiles, cleanPatchFilesFlagUsage)
 	f.BoolVarP(&pull, pullFlagName, pullFlagShorthand, pull, pullFlagUsage)
 	f.BoolVarP(&push, pushFlagName, pushFlagShorthand, push, pushFlagUsage)
 

--- a/cmd/qliksense/install.go
+++ b/cmd/qliksense/install.go
@@ -13,7 +13,7 @@ import (
 func installCmd(q *qliksense.Qliksense) *cobra.Command {
 	opts := &qliksense.InstallCommandOptions{}
 	filePath := ""
-	keepPatchFiles, pull, push := false, false, false
+	cleanPatchFiles, pull, push := true, false, false
 	c := &cobra.Command{
 		Use:   "install",
 		Short: "install a qliksense release",
@@ -29,7 +29,7 @@ func installCmd(q *qliksense.Qliksense) *cobra.Command {
 					} else if err := validatePullPushFlagsOnApply(cr, pull, push); err != nil {
 						return err
 					} else {
-						return q.ApplyCRFromReader(bytes.NewReader(crBytesWithEula), opts, keepPatchFiles, true, pull, push)
+						return q.ApplyCRFromReader(bytes.NewReader(crBytesWithEula), opts, cleanPatchFiles, true, pull, push)
 					}
 				})
 			} else {
@@ -52,7 +52,7 @@ func installCmd(q *qliksense.Qliksense) *cobra.Command {
 						return err
 					}
 				}
-				return q.InstallQK8s(version, opts, keepPatchFiles)
+				return q.InstallQK8s(version, opts, cleanPatchFiles)
 			}
 		},
 	}
@@ -73,7 +73,7 @@ func installCmd(q *qliksense.Qliksense) *cobra.Command {
 	f.StringVarP(&opts.StorageClass, "storageClass", "s", "", "Storage class for qliksense")
 	f.StringVarP(&opts.MongodbUri, "mongodbUri", "m", "", "mongodbUri for qliksense (i.e. mongodb://qlik-default-mongodb:27017/qliksense?ssl=false)")
 	f.StringVarP(&opts.RotateKeys, "rotateKeys", "r", "", "Rotate JWT keys for qliksense (yes:rotate keys/ no:use exising keys from cluster/ None: use default EJSON_KEY from env")
-	f.BoolVar(&keepPatchFiles, keepPatchFilesFlagName, keepPatchFiles, keepPatchFilesFlagUsage)
+	f.BoolVar(&cleanPatchFiles, cleanPatchFilesFlagName, cleanPatchFiles, cleanPatchFilesFlagUsage)
 	f.StringVarP(&filePath, "file", "f", "", "Install from a CR file")
 
 	f.BoolVarP(&opts.DryRun, "dry-run", "", false, "Dry run will generate the patches without rotating keys")

--- a/cmd/qliksense/root.go
+++ b/cmd/qliksense/root.go
@@ -23,17 +23,17 @@ import (
 // qliksense <command>
 
 const (
-	qlikSenseHomeVar        = "QLIKSENSE_HOME"
-	qlikSenseDirVar         = ".qliksense"
-	keepPatchFilesFlagName  = "keep-config-repo-patches"
-	keepPatchFilesFlagUsage = "Keep config repo patch files (for debugging)"
-	pullFlagName            = "pull"
-	pullFlagShorthand       = "d"
-	pullFlagUsage           = "If using private docker registry, pull (download) all required Qliksense images before install"
-	pushFlagName            = "push"
-	pushFlagShorthand       = "u"
-	pushFlagUsage           = "If using private docker registry, push (upload) all downloaded Qliksense images to that registry before install"
-	rootCommandName         = "qliksense"
+	qlikSenseHomeVar         = "QLIKSENSE_HOME"
+	qlikSenseDirVar          = ".qliksense"
+	cleanPatchFilesFlagName  = "clean"
+	cleanPatchFilesFlagUsage = "Set --clean=false to keep any prior config repo file changes on install (for debugging)"
+	pullFlagName             = "pull"
+	pullFlagShorthand        = "d"
+	pullFlagUsage            = "If using private docker registry, pull (download) all required Qliksense images before install"
+	pushFlagName             = "push"
+	pushFlagShorthand        = "u"
+	pushFlagUsage            = "If using private docker registry, push (upload) all downloaded Qliksense images to that registry before install"
+	rootCommandName          = "qliksense"
 )
 
 func initAndExecute() error {

--- a/pkg/qliksense/apply.go
+++ b/pkg/qliksense/apply.go
@@ -7,7 +7,7 @@ import (
 	qapi "github.com/qlik-oss/sense-installer/pkg/api"
 )
 
-func (q *Qliksense) ApplyCRFromReader(r io.Reader, opts *InstallCommandOptions, keepPatchFiles, overwriteExistingContext, pull, push bool) error {
+func (q *Qliksense) ApplyCRFromReader(r io.Reader, opts *InstallCommandOptions, cleanPatchFiles, overwriteExistingContext, pull, push bool) error {
 	if err := q.LoadCr(r, overwriteExistingContext); err != nil {
 		return err
 	}
@@ -40,9 +40,9 @@ func (q *Qliksense) ApplyCRFromReader(r io.Reader, opts *InstallCommandOptions, 
 				}
 			}
 		}
-		return q.UpgradeQK8s(keepPatchFiles)
+		return q.UpgradeQK8s(cleanPatchFiles)
 	}
-	return q.InstallQK8s(version, opts, keepPatchFiles)
+	return q.InstallQK8s(version, opts, cleanPatchFiles)
 }
 
 func IsQliksenseInstalled(crName string) bool {

--- a/pkg/qliksense/fetch.go
+++ b/pkg/qliksense/fetch.go
@@ -138,7 +138,7 @@ func getVersion(opts *FetchCommandOptions, qcr *qapi.QliksenseCR) string {
 
 func getVerionsOverwriteConfirmation(version string) string {
 	reader := bufio.NewReader(os.Stdin)
-	fmt.Println("The version  [" + version + "] already exist")
+	fmt.Println("The version  [" + version + "] already exists")
 	cfm := "n"
 	for {
 		fmt.Print("Do you want to delete and fetch again [y/N]: ")

--- a/pkg/qliksense/install.go
+++ b/pkg/qliksense/install.go
@@ -23,7 +23,7 @@ type InstallCommandOptions struct {
 	DryRun       bool
 }
 
-func (q *Qliksense) InstallQK8s(version string, opts *InstallCommandOptions, keepPatchFiles bool) error {
+func (q *Qliksense) InstallQK8s(version string, opts *InstallCommandOptions, cleanPatchFiles bool) error {
 
 	// step1: fetch 1.0.0 # pull down qliksense-k8s@1.0.0
 	// step2: operator view | kubectl apply -f # operator manifest (CRD)
@@ -32,7 +32,7 @@ func (q *Qliksense) InstallQK8s(version string, opts *InstallCommandOptions, kee
 
 	// fetch the version
 	qConfig := qapi.NewQConfig(q.QliksenseHome)
-	if !keepPatchFiles {
+	if cleanPatchFiles {
 		if err := q.DiscardAllUnstagedChangesFromGitRepo(qConfig); err != nil {
 			fmt.Printf("error removing temporary changes to the config: %v\n", err)
 		}
@@ -123,7 +123,7 @@ func (q *Qliksense) InstallQK8s(version string, opts *InstallCommandOptions, kee
 		return err
 	} else {
 		if IsQliksenseInstalled(dcr.GetName()) {
-			return q.UpgradeQK8s(keepPatchFiles)
+			return q.UpgradeQK8s(cleanPatchFiles)
 		}
 		if err := q.applyConfigToK8s(dcr); err != nil {
 			fmt.Println("cannot do kubectl apply on manifests")

--- a/pkg/qliksense/upgrade.go
+++ b/pkg/qliksense/upgrade.go
@@ -6,7 +6,7 @@ import (
 	qapi "github.com/qlik-oss/sense-installer/pkg/api"
 )
 
-func (q *Qliksense) UpgradeQK8s(keepPatchFiles bool) error {
+func (q *Qliksense) UpgradeQK8s(cleanPatchFiles bool) error {
 
 	// step1: get CR
 	// step2: run kustomize
@@ -14,12 +14,10 @@ func (q *Qliksense) UpgradeQK8s(keepPatchFiles bool) error {
 
 	// fetch the version
 	qConfig := qapi.NewQConfig(q.QliksenseHome)
-	if !keepPatchFiles {
-		defer func() {
-			if err := q.DiscardAllUnstagedChangesFromGitRepo(qConfig); err != nil {
-				fmt.Printf("error removing temporary changes to the config: %v\n", err)
-			}
-		}()
+	if cleanPatchFiles {
+		if err := q.DiscardAllUnstagedChangesFromGitRepo(qConfig); err != nil {
+			fmt.Printf("error removing temporary changes to the config: %v\n", err)
+		}
 	}
 
 	qcr, err := qConfig.GetCurrentCR()


### PR DESCRIPTION
This PR fixes:
1) rename "--keep-config-repo-patches" to "–clean=false" (default true)
2) "The version [v1.50.3] already exist[s]"