### PR TITLE
Autorun postflight checks

### DIFF
--- a/cmd/qliksense/install.go
+++ b/cmd/qliksense/install.go
@@ -24,10 +24,15 @@ func installCmd(q *qliksense.Qliksense) *cobra.Command {
 			}
 
 			if filePath != "" {
-				return apply(q, cmd, opts)
+				if err := apply(q, cmd, opts); err != nil {
+					return err
+				}
 			} else {
-				return q.InstallQK8s(version, opts)
+				if err1 := q.InstallQK8s(version, opts); err1 != nil {
+					return err1
+				}
 			}
+			return AllPostflightChecks(q).Execute()
 		},
 	}
 

--- a/cmd/qliksense/root.go
+++ b/cmd/qliksense/root.go
@@ -217,7 +217,8 @@ func rootCmd(p *qliksense.Qliksense) *cobra.Command {
 
 	// add postflight command
 	postflightCmd := postflightCmd(p)
-	postflightCmd.AddCommand(pfMigrationCheck(p))
+	postflightCmd.AddCommand(postflightMigrationCheck(p))
+	postflightCmd.AddCommand(AllPostflightChecks(p))
 
 	cmd.AddCommand(postflightCmd)
 	return cmd

--- a/docs/postflight_checks.md
+++ b/docs/postflight_checks.md
@@ -20,6 +20,22 @@ Flags:
   -v, --verbose   verbose mode
 ```
 
+### Run all postflight checks
+This command runs all the postflight checks available.
+
+```shell
+$ qliksense postflight all  
+Running all postflight checks...
+
+Postflight db migration check... 
+Logs from pod: qliksense-users-6977cb7788-qlgmv
+{"caller":"main.go:39","environment":"qseok","error":"error parsing uri: scheme must be \"mongodb\" or \"mongodb+srv\"","level":"error","message":"failed to connect to ","timestamp":"2020-06-17T04:10:11.7891913Z","version":""}
+To view more logs in this context, please run the command: kubectl logs -n test_ns qliksense-users-6977cb7788-qlgmv migration
+PASSED
+
+All postflight checks have PASSED
+```
+
 ### DB migration check
 This command checks init containers for successful database migrarion completions, and reports failure, if any to the user.
 
@@ -29,5 +45,7 @@ An example run of this check produces an output as shown below:
 $ qliksense postflight db-migration-check   
 Logs from pod: qliksense-users-6977cb7788-cxxwh
 {"caller":"main.go:39","environment":"qseok","error":"error parsing uri: scheme must be \"mongodb\" or \"mongodb+srv\"","level":"error","message":"failed to connect to ","timestamp":"2020-06-01T01:07:18.4170507Z","version":""}
+To view more logs in this context, please run the command: kubectl logs -n test_ns qliksense-users-6977cb7788-qlgmv migration
+PASSED
 Postflight db_migration_check completed
 ```

--- a/pkg/postflight/all_postflight_checks.go
+++ b/pkg/postflight/all_postflight_checks.go
@@ -1,0 +1,31 @@
+package postflight
+
+import (
+	"fmt"
+
+	. "github.com/logrusorgru/aurora"
+	ansi "github.com/mattn/go-colorable"
+	"github.com/pkg/errors"
+)
+
+func (qp *QliksensePostflight) RunAllPostflightChecks(namespace string, kubeConfigContents []byte, preflightOpts *PostflightOptions) error {
+	checkCount := 0
+	totalCount := 0
+
+	out := ansi.NewColorableStdout()
+	// Postflight db migration check
+	if err := qp.DbMigrationCheck(namespace, kubeConfigContents); err != nil {
+		fmt.Fprintf(out, "%s\n", Red("FAILED"))
+		fmt.Printf("Error: %v\n\n", err)
+	} else {
+		fmt.Fprintf(out, "%s\n\n", Green("PASSED"))
+		checkCount++
+	}
+	totalCount++
+
+	if checkCount == totalCount {
+		// All postflight checks were successful
+		return nil
+	}
+	return errors.New("1 or more postflight checks have FAILED")
+}

--- a/pkg/postflight/db_migration_check.go
+++ b/pkg/postflight/db_migration_check.go
@@ -11,7 +11,8 @@ import (
 const initContainerNameToCheck = "migration"
 
 func (p *QliksensePostflight) DbMigrationCheck(namespace string, kubeConfigContents []byte) error {
-
+	fmt.Printf("Postflight db migration check... \n")
+	p.CG.LogVerboseMessage("\n----------------------------------- \n")
 	clientset, _, err := p.CG.GetK8SClientSet(kubeConfigContents, "")
 	if err != nil {
 		err = fmt.Errorf("unable to create a kubernetes client: %v", err)


### PR DESCRIPTION
- Postflight checks will run automatically right after `qliksense install` completes.
- Added a `qliksense postflight all` command for future use.
- updated doc.

Output:
```
... (output from qliksense install)
...
deployment.apps/qlik-default-redis-slave created
statefulset.apps/qlik-default-redis-master created
configmap/qlik-default-redis-configs-6fdffc5hf6 created
secret/qlik-default-redis-secrets-bf5h6h9744 created

Installing operator CR into the cluster
qliksense.qlik.com/qlik-default created

Running all postflight checks...

Postflight db migration check... 
Logs from pod: qliksense-users-6977cb7788-qlgmv
{"caller":"main.go:39","environment":"qseok","error":"error parsing uri: scheme must be \"mongodb\" or \"mongodb+srv\"","level":"error","message":"failed to connect to ","timestamp":"2020-06-17T04:45:46.6647355Z","version":""}
To view more logs in this context, please run the command: kubectl logs -n test_ns qliksense-users-6977cb7788-qlgmv migration
PASSED

All postflight checks have PASSED
```