### PR TITLE
fix editor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.17.2
 	k8s.io/apimachinery v0.17.2
 	k8s.io/client-go v11.0.0+incompatible
+	k8s.io/kubectl v0.17.2
 	sigs.k8s.io/kustomize/api v0.3.2
 	sigs.k8s.io/yaml v1.1.0
 )

--- a/pkg/qliksense/config.go
+++ b/pkg/qliksense/config.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
@@ -16,6 +15,7 @@ import (
 	"github.com/qlik-oss/k-apis/pkg/cr"
 	"github.com/qlik-oss/sense-installer/pkg/api"
 	qapi "github.com/qlik-oss/sense-installer/pkg/api"
+	"k8s.io/kubectl/pkg/cmd/util/editor"
 )
 
 const (
@@ -196,13 +196,12 @@ func (q *Qliksense) EditCR(contextName string) error {
 	if err := ioutil.WriteFile(tempFile.Name(), crContent, os.ModePerm); err != nil {
 		return nil
 	}
-	cmd := exec.Command(getKubeEditorTool(), tempFile.Name())
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	err = cmd.Run()
-	if err != nil {
+
+	currentEditor := editor.NewDefaultEditor([]string{"KUBE_EDITOR", "EDITOR"})
+	if err = currentEditor.Launch(tempFile.Name()); err != nil {
 		return err
 	}
+
 	newCr, err := qapi.GetCRObject(tempFile.Name())
 	if err != nil {
 		return errors.New("cannot save the cr. Someting wrong in the file format. It is not saved\n" + err.Error())
@@ -216,12 +215,4 @@ func (q *Qliksense) EditCR(contextName string) error {
 		return qConfig.WriteCR(newCr)
 	}
 	return nil
-}
-
-func getKubeEditorTool() string {
-	editor := os.Getenv("KUBE_EDITOR")
-	if editor == "" {
-		editor = "vim"
-	}
-	return editor
 }


### PR DESCRIPTION
Signed-off-by: Foysal Iqbal <mqb@qlik.com>

Now `qliksense config edit` used kubectl library, so should work on all platform as kubectl