### PR TITLE
Preflight openssl verify

### DIFF
--- a/cmd/qliksense/root.go
+++ b/cmd/qliksense/root.go
@@ -209,6 +209,7 @@ func rootCmd(p *qliksense.Qliksense) *cobra.Command {
 	preflightCmd.AddCommand(pfCreateRoleBindingCheckCmd(p))
 	preflightCmd.AddCommand(pfCreateServiceAccountCheckCmd(p))
 	preflightCmd.AddCommand(pfCreateAuthCheckCmd(p))
+	preflightCmd.AddCommand(pfVerifyCAChainCmd(p))
 	preflightCmd.AddCommand(pfCleanupCmd(p))
 
 	cmd.AddCommand(preflightCmd)

--- a/docs/preflight_checks.md
+++ b/docs/preflight_checks.md
@@ -305,3 +305,21 @@ Removing mongo check components...
 Preflight cleanup complete
 
 ```
+
+### Verify-ca-chain check
+We use the command below to verify the ca certificate chain and server certificate. We run this check over mongodbUrl and discoveryUrl we inferred from idpconfigs in the CR.
+```shell
+$ qliksense preflight preflight verify-ca-chain -v
+
+Preflight verify-ca-chain check... 
+----------------------------------- 
+Openssl verify mongodbUrl:
+Mongodb url inferred form CR: <mongodbUrl_from_CR>
+Host: <host extracted from mongodbUrl>
+
+Openssl verify discoveryUrl:
+Discovery url: <discoveryUrl_from_CR>
+Host: <host extracted from discoveryUrl>
+Completed preflight verify-CA-chain check
+PASSED
+```

--- a/pkg/preflight/all_checks.go
+++ b/pkg/preflight/all_checks.go
@@ -103,6 +103,16 @@ func (qp *QliksensePreflight) RunAllPreflightChecks(kubeConfigContents []byte, n
 	}
 	totalCount++
 
+	// Preflight verify ca chain check
+	if err := qp.VerifyCAChain(kubeConfigContents, namespace, preflightOpts, false); err != nil {
+		fmt.Fprintf(out, "%s\n", Red("FAILED"))
+		fmt.Printf("Error: %v\n\n", err)
+	} else {
+		fmt.Fprintf(out, "%s\n\n", Green("PASSED"))
+		checkCount++
+	}
+	totalCount++
+
 	if checkCount == totalCount {
 		// All preflight checks were successful
 		return nil

--- a/pkg/preflight/verify_ca.go
+++ b/pkg/preflight/verify_ca.go
@@ -81,9 +81,7 @@ func (qp *QliksensePreflight) extractCertAndVerify(server string, caCertificates
 	}
 
 	qp.CG.LogVerboseMessage("Host: %s, port: %s\n", u.Host, u.Port())
-	conn, err := tls.Dial("tcp", u.Host, &tls.Config{
-		// InsecureSkipVerify: true,
-	})
+	conn, err := tls.Dial("tcp", u.Host, &tls.Config{})
 	if err != nil {
 		return fmt.Errorf("failed to connect: " + err.Error())
 	}
@@ -104,7 +102,7 @@ func (qp *QliksensePreflight) extractCertAndVerify(server string, caCertificates
 	if !ok {
 		return fmt.Errorf("failed to parse root certificate.")
 	}
-	// roots.AddCert(x509Certificates[0]) // TESTING....
+
 	opts := x509.VerifyOptions{
 		Roots:         roots,
 		DNSName:       u.Hostname(),

--- a/pkg/preflight/verify_ca.go
+++ b/pkg/preflight/verify_ca.go
@@ -62,6 +62,8 @@ func (qp *QliksensePreflight) VerifyCAChain(kubeConfigContents []byte, namespace
 	if err := qp.extractCertAndVerify(discoveryUrl, caCertificates); err != nil {
 		return err
 	}
+
+	qp.CG.LogVerboseMessage("Completed preflight verify-ca-chain check\n")
 	return nil
 }
 
@@ -82,6 +84,7 @@ func (qp *QliksensePreflight) extractCertAndVerify(server string, caCertificates
 
 	qp.CG.LogVerboseMessage("Host: %s, port: %s\n", u.Host, u.Port())
 	conn, err := tls.Dial("tcp", u.Host, &tls.Config{})
+	qp.CG.LogVerboseMessage("Host: %s\n", u.Host)
 	if err != nil {
 		return fmt.Errorf("failed to connect: " + err.Error())
 	}

--- a/pkg/preflight/verify_ca.go
+++ b/pkg/preflight/verify_ca.go
@@ -1,0 +1,34 @@
+package preflight
+
+import (
+	"fmt"
+	"strings"
+
+	qapi "github.com/qlik-oss/sense-installer/pkg/api"
+)
+
+func (qp *QliksensePreflight) VerifyCAChain(kubeConfigContents []byte, namespace string, preflightOpts *PreflightOptions, cleanup bool) error {
+
+	var currentCR *qapi.QliksenseCR
+	var err error
+	qConfig := qapi.NewQConfig(qp.Q.QliksenseHome)
+	qConfig.SetNamespace(namespace)
+	currentCR, err = qConfig.GetCurrentCR()
+	if err != nil {
+		qp.CG.LogVerboseMessage("Unable to retrieve current CR: %v\n", err)
+		return err
+	}
+	decryptedCR, err := qConfig.GetDecryptedCr(currentCR)
+	if err != nil {
+		qp.CG.LogVerboseMessage("An error occurred while retrieving mongodbUrl from current CR: %v\n", err)
+		return err
+	}
+
+	// infer mongodb url from CR
+	preflightOpts.MongoOptions.MongodbUrl = strings.TrimSpace(decryptedCR.Spec.GetFromSecrets("qliksense", "mongodbUri"))
+	fmt.Printf("Mongodb url inferred form CR: %s\n", preflightOpts.MongoOptions.MongodbUrl)
+	// retrieve certs from server
+
+	// execute verify cmd
+	return nil
+}

--- a/pkg/preflight/verify_ca.go
+++ b/pkg/preflight/verify_ca.go
@@ -2,8 +2,10 @@ package preflight
 
 import (
 	"crypto/tls"
-	"flag"
+	"crypto/x509"
+	"encoding/json"
 	"fmt"
+	"net/url"
 	"strings"
 
 	qapi "github.com/qlik-oss/sense-installer/pkg/api"
@@ -16,6 +18,9 @@ func (qp *QliksensePreflight) VerifyCAChain(kubeConfigContents []byte, namespace
 	qConfig := qapi.NewQConfig(qp.Q.QliksenseHome)
 	qConfig.SetNamespace(namespace)
 
+	fmt.Print("Preflight verify-ca-chain check... ")
+	qp.CG.LogVerboseMessage("\n----------------------------------- \n")
+
 	currentCR, err = qConfig.GetCurrentCR()
 	if err != nil {
 		qp.CG.LogVerboseMessage("Unable to retrieve current CR: %v\n", err)
@@ -27,30 +32,86 @@ func (qp *QliksensePreflight) VerifyCAChain(kubeConfigContents []byte, namespace
 		return err
 	}
 
+	// infer ca certs form CR
+	caCertificates := strings.TrimSpace(decryptedCR.Spec.GetFromSecrets("qliksense", "caCertificates"))
+
+	fmt.Println("Openssl verify mongodbUrl:")
 	// infer mongodb url from CR
-	preflightOpts.MongoOptions.MongodbUrl = strings.TrimSpace(decryptedCR.Spec.GetFromSecrets("qliksense", "mongodbUri"))
-	fmt.Printf("Mongodb url inferred form CR: %s\n", preflightOpts.MongoOptions.MongodbUrl)
+	mongodbUrl := strings.TrimSpace(decryptedCR.Spec.GetFromSecrets("qliksense", "mongodbUri"))
+	qp.CG.LogVerboseMessage("Mongodb url inferred form CR: %s\n", mongodbUrl)
 
-	// TODO: parse out server and port frim mongodb url
+	// parse out server and port from mongodb url and execute openssl verify
+	if err := qp.extractCertAndVerify(mongodbUrl, caCertificates); err != nil {
+		return err
+	}
 
-	// retrieve certs from server
-	server := flag.String("server", preflightOpts.MongoOptions.MongodbUrl, "Server to ping")
-	port := flag.Uint("port", 27018, "Port that has TLS")
-	flag.Parse()
+	fmt.Printf("\nOpenssl verify discoveryUrl:\n")
+	// infer idpConfigs form CR
+	idpConfigs := strings.TrimSpace(decryptedCR.Spec.GetFromSecrets("identity-providers", "idpConfigs"))
 
-	conn, err := tls.Dial("tcp", fmt.Sprintf("%s:%d", *server, *port), &tls.Config{
-		InsecureSkipVerify: true,
+	data := []map[string]interface{}{}
+	if err := json.Unmarshal([]byte(idpConfigs), &data); err != nil {
+		panic(err)
+	}
+
+	var discoveryUrl string
+	for _, idpData := range data {
+		discoveryUrl = idpData["discoveryUrl"].(string)
+		qp.CG.LogVerboseMessage("Discovery url: %s\n", discoveryUrl)
+	}
+	if err := qp.extractCertAndVerify(discoveryUrl, caCertificates); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (qp *QliksensePreflight) extractCertAndVerify(server string, caCertificates string) error {
+	u, err := url.Parse(server)
+	if err != nil {
+		return fmt.Errorf("unable to parse url: %v", err)
+	}
+
+	switch strings.ToLower(u.Scheme) {
+	case "http":
+		return fmt.Errorf("http url is not supported for this operation")
+	case "https":
+		if u.Port() == "" {
+			u.Host += ":443"
+		}
+	}
+
+	qp.CG.LogVerboseMessage("Host: %s, port: %s\n", u.Host, u.Port())
+	conn, err := tls.Dial("tcp", u.Host, &tls.Config{
+		// InsecureSkipVerify: true,
 	})
 	if err != nil {
-		panic("failed to connect: " + err.Error())
+		return fmt.Errorf("failed to connect: " + err.Error())
 	}
-	conn.Close()
+	defer conn.Close()
 
 	// Get the ConnectionState struct as that's the one which gives us x509.Certificate struct
-	fmt.Printf("length: %d\n", len(conn.ConnectionState().PeerCertificates))
-	fmt.Printf("%v\n", conn.ConnectionState().PeerCertificates)
+	x509Certificates := conn.ConnectionState().PeerCertificates
 
-	// TODO: execute verify cmd
-
+	if len(x509Certificates) == 0 {
+		return fmt.Errorf("no server certificates retrieved from the server")
+	}
+	if len(x509Certificates) > 1 {
+		return fmt.Errorf("more than 1 server certificate retrieved from the server")
+	}
+	//  execute verify cmd
+	roots := x509.NewCertPool()
+	ok := roots.AppendCertsFromPEM([]byte(caCertificates))
+	if !ok {
+		return fmt.Errorf("failed to parse root certificate.")
+	}
+	// roots.AddCert(x509Certificates[0]) // TESTING....
+	opts := x509.VerifyOptions{
+		Roots:         roots,
+		DNSName:       u.Hostname(),
+		Intermediates: x509.NewCertPool(),
+	}
+	if _, err := x509Certificates[0].Verify(opts); err != nil {
+		return fmt.Errorf("failed to verify certificate: " + err.Error())
+	}
 	return nil
 }


### PR DESCRIPTION
Preflight check to verify the ca chain for:
- mongodbUrl
- discoveryUrl from IdpConfigs

output:
```
$ qliksense preflight verify-ca-chain -v              
Preflight verify-ca-chain check... 
----------------------------------- 
Openssl verify mongodbUrl:
Mongodb url inferred form CR: mongodb://localhost:27018/qliksense?ssl=false
Host: localhost:27018, port: 27018

Openssl verify discoveryUrl:
Discovery url: https://localhost:8080/auth/realms/Qlik/.well-known/openid-configuration
Host: localhost:8080, port: 8080
PASSED
```